### PR TITLE
Fix calendar event deletion in Moodle 3.3

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -191,6 +191,13 @@ function questionnaire_delete_instance($id) {
 
     $result = true;
 
+    if ($events = $DB->get_records('event', array("modulename" => 'questionnaire', "instance" => $questionnaire->id))) {
+        foreach ($events as $event) {
+            $event = calendar_event::load($event);
+            $event->delete();
+        }
+    }
+
     if (! $DB->delete_records('questionnaire', array('id' => $questionnaire->id))) {
         $result = false;
     }
@@ -199,13 +206,6 @@ function questionnaire_delete_instance($id) {
         // If this survey is owned by this course, delete all of the survey records and responses.
         if ($survey->courseid == $questionnaire->course) {
             $result = $result && questionnaire_delete_survey($questionnaire->sid, $questionnaire->id);
-        }
-    }
-
-    if ($events = $DB->get_records('event', array("modulename" => 'questionnaire', "instance" => $questionnaire->id))) {
-        foreach ($events as $event) {
-            $event = calendar_event::load($event);
-            $event->delete();
         }
     }
 


### PR DESCRIPTION
Found this while running \core_calendar_container_testcase::test_delete_module_delete_events.
In 3.3, when you load the event, the API expects that the instance record
still exits.