### PR TITLE
Added support for block_myoverview in Moodle 3.3+

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -138,8 +138,10 @@ function questionnaire_add_instance($questionnaire) {
 
     questionnaire_set_events($questionnaire);
 
-    $completiontimeexpected = !empty($questionnaire->completionexpected) ? $questionnaire->completionexpected : null;
-    \core_completion\api::update_completion_date_event($questionnaire->coursemodule, 'questionnaire', $questionnaire->id, $completiontimeexpected);
+    if (class_exists('\core_completion\api')) {
+        $completiontimeexpected = !empty($questionnaire->completionexpected) ? $questionnaire->completionexpected : null;
+        \core_completion\api::update_completion_date_event($questionnaire->coursemodule, 'questionnaire', $questionnaire->id, $completiontimeexpected);
+    }
 
     return $questionnaire->id;
 }
@@ -178,8 +180,10 @@ function questionnaire_update_instance($questionnaire) {
 
     questionnaire_set_events($questionnaire);
 
-    $completiontimeexpected = !empty($questionnaire->completionexpected) ? $questionnaire->completionexpected : null;
-    \core_completion\api::update_completion_date_event($questionnaire->coursemodule, 'questionnaire', $questionnaire->id, $completiontimeexpected);
+    if (class_exists('\core_completion\api')) {
+        $completiontimeexpected = !empty($questionnaire->completionexpected) ? $questionnaire->completionexpected : null;
+        \core_completion\api::update_completion_date_event($questionnaire->coursemodule, 'questionnaire', $questionnaire->id, $completiontimeexpected);
+    }
 
     return $DB->update_record("questionnaire", $questionnaire);
 }

--- a/lib.php
+++ b/lib.php
@@ -138,6 +138,9 @@ function questionnaire_add_instance($questionnaire) {
 
     questionnaire_set_events($questionnaire);
 
+    $completiontimeexpected = !empty($questionnaire->completionexpected) ? $questionnaire->completionexpected : null;
+    \core_completion\api::update_completion_date_event($questionnaire->coursemodule, 'questionnaire', $questionnaire->id, $completiontimeexpected);
+
     return $questionnaire->id;
 }
 
@@ -174,6 +177,9 @@ function questionnaire_update_instance($questionnaire) {
     questionnaire_grade_item_update($questionnaire);
 
     questionnaire_set_events($questionnaire);
+
+    $completiontimeexpected = !empty($questionnaire->completionexpected) ? $questionnaire->completionexpected : null;
+    \core_completion\api::update_completion_date_event($questionnaire->coursemodule, 'questionnaire', $questionnaire->id, $completiontimeexpected);
 
     return $DB->update_record("questionnaire", $questionnaire);
 }
@@ -1162,3 +1168,34 @@ function questionnaire_get_completion_state($course, $cm, $userid, $type) {
         return $type;
     }
 }
+
+/**
+ * This function receives a calendar event and returns the action associated with it, or null if there is none.
+ *
+ * This is used by block_myoverview in order to display the event appropriately. If null is returned then the event
+ * is not displayed on the block.
+ *
+ * @param calendar_event $event
+ * @param \core_calendar\action_factory $factory
+ * @return \core_calendar\local\event\entities\action_interface|null
+ */
+function mod_questionnaire_core_calendar_provide_event_action(calendar_event $event,
+                                                            \core_calendar\action_factory $factory) {
+    $cm = get_fast_modinfo($event->courseid)->instances['questionnaire'][$event->instance];
+
+    $completion = new \completion_info($cm->get_course());
+
+    $completiondata = $completion->get_data($cm, false);
+
+    if ($completiondata->completionstate != COMPLETION_INCOMPLETE) {
+        return null;
+    }
+
+    return $factory->create_instance(
+            get_string('view'),
+            new \moodle_url('/mod/questionnaire/view.php', ['id' => $cm->id]),
+            1,
+            true
+    );
+}
+


### PR DESCRIPTION
cf. https://docs.moodle.org/dev/Calendar_API#Action_events

According to Moodle 3.3 documentation, the new Course Overview block displays notifications in My Page when a teacher sets an 'Expect completed on' date in the activity completion settings. This works will core modules and should work consistently with 3rd-party modules as well.

see https://docs.moodle.org/33/en/Course_overview 

The proposed changes would implement this in mod_questionnaire