### PR TITLE
Stop looping if section number isn't positive

### DIFF
--- a/questionnaire.class.php
+++ b/questionnaire.class.php
@@ -702,7 +702,7 @@ class questionnaire {
                 if (questionnaire_has_dependencies($this->questions)) {
                     $nbquestionsonpage = questionnaire_nb_questions_on_page($this->questions,
                                     $this->questionsbysec[$formdata->sec], $formdata->rid);
-                    while (count($nbquestionsonpage) == 0) {
+                    while (count($nbquestionsonpage) == 0 && $formdata->sec > 0) {
                         $formdata->sec--;
                         $nbquestionsonpage = questionnaire_nb_questions_on_page($this->questions,
                                         $this->questionsbysec[$formdata->sec], $formdata->rid);


### PR DESCRIPTION
We experienced a glitch which caused the section number to become
negative.  This spawned millions of errors as the loop continued to
attempt to calculate the questionsbysec for a negative section number.