### PR TITLE
Submit preview button not rendered with classes in Boost.

### DIFF
--- a/classes/output/renderer.php
+++ b/classes/output/renderer.php
@@ -322,7 +322,7 @@ class renderer extends \plugin_renderer_base {
     public function print_preview_formend($url, $submitstr, $resetstr) {
         $output = '';
         $output .= \html_writer::start_tag('div');
-        $output .= \html_writer::empty_tag('input', ['type' => 'submit', 'name' => 'submit', 'value' => $submitstr]);
+        $output .= \html_writer::empty_tag('input', ['type' => 'submit', 'name' => 'submit', 'value' => $submitstr, 'class' => 'btn btn-primary']);
         $output .= ' ';
         $output .= \html_writer::tag('a', $resetstr, ['href' => $url]);
         $output .= \html_writer::end_tag('div') . "\n";


### PR DESCRIPTION

The "Submit preview" button could use some bootstrap classes.

<img width="1098" alt="issue 143" src="https://user-images.githubusercontent.com/377279/44053069-d63a4b72-9f3e-11e8-856d-c207d3e21bbe.png">