### PR TITLE
Enhancement for Download Responses

### DIFF
--- a/classes/output/renderer.php
+++ b/classes/output/renderer.php
@@ -444,4 +444,46 @@ class renderer extends \plugin_renderer_base {
 
         return $o;
     }
+
+    /**
+     * Returns a dataformat selection and download form
+     *
+     * @param string $label A text label
+     * @param moodle_url|string $base The download page url
+     * @param string $name The query param which will hold the type of the download
+     * @param array $params Extra params sent to the download page
+     * @return string HTML fragment
+     * @throws \coding_exception
+     * @throws \moodle_exception
+     */
+    public function render_export_format_selector($label, $base, $name = 'dataformat', $params = array()) {
+        $formats = \core_plugin_manager::instance()->get_plugins_of_type('dataformat');
+        $options = array();
+        foreach ($formats as $format) {
+            if ($format->is_enabled()) {
+                $options[] = array(
+                        'value' => $format->name,
+                        'label' => get_string('dataformat', $format->component),
+                );
+            }
+        }
+        $hiddenparams = array();
+        foreach ($params as $key => $value) {
+            $hiddenparams[] = array(
+                    'name' => $key,
+                    'value' => $value,
+            );
+        }
+        $data = array(
+                'label' => $label,
+                'base' => $base,
+                'name' => $name,
+                'params' => $hiddenparams,
+                'options' => $options,
+                'sesskey' => sesskey(),
+                'submit' => get_string('download'),
+        );
+
+        return $this->render_from_template('questionnaire/export_selector', $data);
+    }
 }

--- a/lang/en/questionnaire.php
+++ b/lang/en/questionnaire.php
@@ -129,8 +129,7 @@ $string['directwarnings'] = 'Direct dependencies to this question will be remove
 $string['displaymethod'] = 'Display method not defined for question.';
 $string['download'] = 'Download';
 $string['downloadtextformat'] = 'Download in text format';
-$string['downloadtextformat_help'] = 'This feature enables you to save all the responses of a questionnaire to a text file (CSV).
- This file can then be imported into a spreadsheet (e.g. MS Excel or Open Office Calc) or a statistical package for further processing the data.';
+$string['downloadtextformat_help'] = 'This feature enables you to download questionnaire responses in a file format of your choice. The file can then be opened in a spreadsheet program (e.g. MS Excel or Open Office Calc) or a statistical package for further processing.';
 $string['downloadtextformat_link'] = 'mod/questionnaire/report#Download_in_text_format';
 $string['dropdown'] = 'Dropdown Box';
 $string['dropdown_help'] = 'There is no real advantage to using the Dropdown Box over using the Radio Buttons
@@ -570,7 +569,7 @@ $string['textarearows'] = 'Textarea rows';
 $string['textbox'] = 'Text Box';
 $string['textbox_help'] = 'For the Text Box question type, enter the Input Box length and the Maximum text length of text to be entered by respondent.
 Default values are 20 characters for the Input Box width and 25 characters for the maximum length of text entered.';
-$string['textdownloadoptions'] = 'Options for text download (CSV)';
+$string['textdownloadoptions'] = 'Options for download';
 $string['thank_head'] = 'Thank you for completing this Questionnaire.';
 $string['theme'] = 'Theme';
 $string['thismonth'] = 'this month';
@@ -614,3 +613,6 @@ $string['yesno_help'] = 'Simple Yes/No question.';
 $string['yourresponse'] = 'Your response';
 $string['yourresponses'] = 'Your responses';
 $string['crontask'] = 'Questionnaire cleanup job';
+$string['unknowformat'] = 'Unknown format type';
+$string['downloadas'] = 'Download data as';
+$string['downloadresponses'] = 'Download responses';

--- a/tabs.php
+++ b/tabs.php
@@ -161,7 +161,7 @@ if (($canviewallgroups || ($canviewgroups && $questionnaire->capabilities->reada
         if ($questionnaire->capabilities->downloadresponses) {
             $argstr2 = $argstr.'&action=dwnpg&group='.$currentgroupid;
             $link  = $CFG->wwwroot.htmlspecialchars('/mod/questionnaire/report.php?'.$argstr2);
-            $row3[] = new tabobject('downloadcsv', $link, get_string('downloadtext'));
+            $row3[] = new tabobject('downloadcsv', $link, get_string('downloadresponses', 'questionnaire'));
         }
     }
 

--- a/templates/export_selector.mustache
+++ b/templates/export_selector.mustache
@@ -1,0 +1,62 @@
+{{!
+    This file is part of Moodle - http://moodle.org/
+
+    Moodle is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Moodle is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+}}
+{{!
+    @template mod_questionnaire/export_selector
+
+    Template for dataformat selection and download form.
+
+    Context variables required for this template:
+    * label
+    * base
+    * name
+    * params
+    * options
+    * sesskey
+    * submit
+
+    Example context (json):
+    {
+        "base": "http://example.org/",
+        "name": "test",
+        "label": "Download table data as",
+        "params": false,
+        "options": [{"label": "CSV", "name": "csv"}, {"label": "Excel", "name": "excel"}],
+        "submit": "Download"
+    }
+}}
+<form method="get" action="{{base}}" class="dataformatselector">
+    <div>
+        <input id="choicecodes" value="1" name="choicecodes" checked="checked" type="checkbox">
+        <label for="choicecodes">Include choice codes</label>
+        <br>
+        <input id="choicetext" value="1" name="choicetext" checked="checked" type="checkbox">
+        <label for="choicetext">Include choice text</label>
+    </div>
+    <div>
+        <input type="hidden" name="sesskey" value="{{sesskey}}">
+        <label for="downloadtype_{{name}}">{{label}}</label>
+        <select name="{{name}}" id="downloadtype_{{name}}">
+            {{#options}}
+                <option value="{{value}}">{{label}}</option>
+            {{/options}}
+        </select>
+        <input type="submit" value="{{submit}}">
+        {{#params}}
+            <input type="hidden" name="{{name}}" value="{{value}}"/>
+        {{/params}}
+    </div>
+</form>


### PR DESCRIPTION
Hi @mchurchward ,
I'm using this plugin, it's very useful. Thanks for making this
Currently, I can download the responses from Questionnaire as a text (.txt) file. Usually, I would want to open the responses in MS Excel or Open Office Calc, but in Office 2016 onwards it seems to have become a lot harder to open and interpret tabbed text files in Excel.

So I would like to make a Pull Request to contribute some of my code to make the Download feature support more format like the Quiz module of Moodle.


Support:
 * Comma separated values (.csv)
 * Microsoft Excel (.xlsx)
 * HTML Table (.html)
 * JavaScript Object Notation (.json)
 * OpenDocument (.ods)

Please help to review and feel free to ask me if you have any concern.
Thanks,
Huong Nguyen