### PR TITLE
Fix SQL query to work with groups, use the correct groupid field.

### DIFF
--- a/questionnaire.class.php
+++ b/questionnaire.class.php
@@ -575,7 +575,7 @@ class questionnaire {
         $groupcnd = '';
         if ($groupid != 0) {
             $groupsql = 'INNER JOIN {groups_members} gm ON r.userid = gm.userid ';
-            $groupcnd = ' AND gm.id = :groupid ';
+            $groupcnd = ' AND gm.groupid = :groupid ';
             $params['groupid'] = $groupid;
         }
 
@@ -621,7 +621,7 @@ class questionnaire {
         $groupcnd = '';
         if ($groupid != 0) {
             $groupsql = 'INNER JOIN {groups_members} gm ON r.userid = gm.userid ';
-            $groupcnd = ' AND gm.id = :groupid ';
+            $groupcnd = ' AND gm.groupid = :groupid ';
             $params['groupid'] = $groupid;
         }
 


### PR DESCRIPTION
Related to issue #162 

There's an error in a couple of SQL querys using id field from groups_members to match the current group when groupid field is the correct one.

