### PR TITLE
Provide a 'More help' link to MoodleDocs in activity chooser.

### DIFF
--- a/lang/en/questionnaire.php
+++ b/lang/en/questionnaire.php
@@ -280,6 +280,7 @@ $string['missingquestion'] = 'Please answer Required question ';
 $string['missingquestions'] = 'Please answer Required questions: ';
 $string['modulename'] = 'Questionnaire';
 $string['modulename_help'] = 'The questionnaire module allows you to construct surveys using a variety of question types, for the purpose of gathering data from users.';
+$string['modulename_link'] = 'mod/questionnaire/view';
 $string['modulenameplural'] = 'Questionnaires';
 $string['movedisabled'] = 'This item cannot be moved';
 $string['myresponses'] = 'All your responses';


### PR DESCRIPTION
Thanks!
That would provide such a link:
<img width="357" alt="activitychooserdocslink" src="https://user-images.githubusercontent.com/377279/60026950-d5f24600-969c-11e9-84a3-e4b847cd71c9.png">
