### PR TITLE
Anonymous questionnaire breaks anonimity in individual responses.

### DIFF
--- a/questionnaire.class.php
+++ b/questionnaire.class.php
@@ -3243,7 +3243,10 @@ class questionnaire {
         if ($resp = $DB->get_record('questionnaire_response', ['id' => $rid]) ) {
             $userid = $resp->userid;
             if ($user = $DB->get_record('user', ['id' => $userid])) {
-                $ruser = fullname($user);
+                if ($this->respondenttype == 'anonymous')
+                    $ruser = '- '.get_string('anonymous', 'questionnaire').' -';
+                else
+                    $ruser = fullname($user);
             }
         }
         // Available group modes (0 = no groups; 1 = separate groups; 2 = visible groups).


### PR DESCRIPTION
When a questionnaire is set to anonymous the name of the user who responded is still shown in the overview of the individual responses.
![image001](https://user-images.githubusercontent.com/30812282/65508113-c79c0c00-decf-11e9-959e-1a59e655c8ef.png)
