### PR TITLE
Align answer options (radio buttons)

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -262,6 +262,14 @@ td.selected {
     overflow: auto;
 }
 
+.qn-answer input[type=radio] {
+    margin-left: 0.5em;
+}
+
+.qn-answer > label + input[type=radio] {
+    margin-left: 0;
+}
+
 #notice .qn-question {
     margin: 0;
 }


### PR DESCRIPTION
Let's align the radio buttons which otherwise would be cut.

<img width="666" alt="alignansweroptions" src="https://user-images.githubusercontent.com/377279/70437566-2d8a3f80-1a8c-11ea-9288-011312a8523c.png">

What the css does is indenting all input of type radio except if they are preceeded by option (that's when they are horizontally one option after another).