### PR TITLE
Clean user essay response

### DIFF
--- a/classes/responsetype/text.php
+++ b/classes/responsetype/text.php
@@ -208,7 +208,7 @@ class text extends responsetype {
             $users = [];
             foreach ($weights as $row) {
                 $response = new \stdClass();
-                $response->text = format_text($row->response, FORMAT_HTML, ['noclean' => true]);
+                $response->text = format_text($row->response, FORMAT_HTML);
                 if ($viewsingleresponse && $nonanonymous) {
                     $rurl = $url.'&amp;rid='.$row->rid.'&amp;individualresponse=1';
                     $title = userdate($row->submitted);


### PR DESCRIPTION
The response summary page didn't clean the essay responses. Students could add untrusted content (e.g. javascript) to their essay responses and the browser executed this.

Please cherry pick this commit also to the 3.7 branch.