### PR TITLE
Prevent a PHP Warning: count(): Parameter must be an array or an object

### DIFF
--- a/show_nonrespondents.php
+++ b/show_nonrespondents.php
@@ -271,7 +271,11 @@ if ($fullname) {
         $usedgroupid = false;
     }
     $nonrespondents = questionnaire_get_incomplete_users($cm, $sid, $usedgroupid);
-    $countnonrespondents = count($nonrespondents);
+    if (is_array($nonrespondents) || is_object($nonrespondents)) {
+        $countnonrespondents = count($nonrespondents);
+    } else {
+        $countnonrespondents = 0;
+    }
 
     $table->initialbars(false);
 


### PR DESCRIPTION
when no participants are in a course and you call 'Non-respondents'.