### PR TITLE
Add css class for mobile handler

### DIFF
--- a/db/mobile.php
+++ b/db/mobile.php
@@ -30,7 +30,7 @@ $addons = [
             'questionsview' => [
                 'displaydata' => [
                     'icon' => $CFG->wwwroot . '/mod/questionnaire/pix/icon.svg',
-                    'class' => '',
+                    'class' => 'core-course-module-questionnaire-handler',
                 ],
                 'delegate' => 'CoreCourseModuleDelegate',
                 'method' => 'mobile_view_activity',


### PR DESCRIPTION
We want to custom css of questionnair module on the mobile app, but the mobile handler is missing css class.
Could you please add a class call core-course-module-questionnair-handler to php file below? https://github.com/PoetOS/moodle-mod_questionnaire/blob/master/db/mobile.php