### PR TITLE
CONTRIB-7264: Add option to exclude inactive users' responses

### DIFF
--- a/backup/moodle2/backup_questionnaire_stepslib.php
+++ b/backup/moodle2/backup_questionnaire_stepslib.php
@@ -40,7 +40,7 @@ class backup_questionnaire_activity_structure_step extends backup_activity_struc
         // Define each element separated.
         $questionnaire = new backup_nested_element('questionnaire', array('id'), array(
             'course', 'name', 'intro', 'introformat', 'qtype',
-            'respondenttype', 'resp_eligible', 'resp_view', 'notifications', 'opendate',
+            'respondenttype', 'resp_eligible', 'resp_view', 'excludeinactive', 'notifications', 'opendate',
             'closedate', 'resume', 'navigate', 'grade', 'sid', 'timemodified', 'completionsubmit', 'autonum'));
 
         $surveys = new backup_nested_element('surveys');

--- a/classes/responsetype/responsetype.php
+++ b/classes/responsetype/responsetype.php
@@ -307,9 +307,12 @@ abstract class responsetype {
      * @param bool|int $responseid
      * @param bool|int $userid
      * @param bool|int $groupid
+     * @param bool $excludeinactive Exclude responses from inactive users
+     * @param \context $context Context of questionnaire
      * @return array
      */
-    public function get_bulk_sql($questionnaireids, $responseid = false, $userid = false, $groupid = false, $showincompletes = 0) {
+    public function get_bulk_sql($questionnaireids, $responseid = false, $userid = false, $groupid = false, $showincompletes = 0,
+                                 $excludeinactive = false, \context $context = null) {
         global $DB;
 
         $sql = $this->bulk_sql();
@@ -347,6 +350,15 @@ abstract class responsetype {
         } else if ($userid) {
             $sql .= " WHERE qr.userid = ?";
             $params[] = $userid;
+        } else if ($excludeinactive) {
+            if ($users = get_enrolled_users($context, 'mod/questionnaire:submit', 0, 'u.id', null, 0, 0, true)) {
+                $userids = array_map(function($u) {
+                    return $u->id;
+                }, $users);
+                list($usersql, $userparams) = $DB->get_in_or_equal($userids);
+                $sql .= " WHERE qr.userid $usersql ";
+                $params = array_merge($params, $userparams);
+            }
         }
 
         return [$sql, $params];

--- a/classes/responsetype/single.php
+++ b/classes/responsetype/single.php
@@ -335,9 +335,13 @@ class single extends responsetype {
      * @param int|array $questionnaireids One id, or an array of ids.
      * @param bool|int $responseid
      * @param bool|int $userid
+     * @param bool|int $groupid
+     * @param bool $excludeinactive Exclude responses from inactive users
+     * @param \context $context Context of questionnaire
      * @return array
      */
-    public function get_bulk_sql($questionnaireids, $responseid = false, $userid = false, $groupid = false, $showincompletes = 0) {
+    public function get_bulk_sql($questionnaireids, $responseid = false, $userid = false, $groupid = false, $showincompletes = 0,
+                                 $excludeinactive = false, \context $context = null) {
         global $DB;
 
         $sql = $this->bulk_sql();
@@ -376,6 +380,15 @@ class single extends responsetype {
         } else if ($userid) {
             $sql .= " WHERE qr.userid = ?";
             $params[] = $userid;
+        } else if ($excludeinactive) {
+            if ($users = get_enrolled_users($context, 'mod/questionnaire:submit', 0, 'u.id', null, 0, 0, true)) {
+                $userids = array_map(function($u) {
+                    return $u->id;
+                }, $users);
+                list($usersql, $userparams) = $DB->get_in_or_equal($userids);
+                $sql .= " WHERE qr.userid $usersql ";
+                $params = array_merge($params, $userparams);
+            }
         }
 
         return [$sql, $params];

--- a/db/install.xml
+++ b/db/install.xml
@@ -26,6 +26,7 @@
         <FIELD NAME="completionsubmit" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Questionnaire marked as 'complete' when submitted."/>
         <FIELD NAME="autonum" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="3" SEQUENCE="false" COMMENT="option for auto numbering questions and pages (both selected by default)"/>
         <FIELD NAME="progressbar" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Display a progress bar at top of questionnaire."/>
+        <FIELD NAME="excludeinactive" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Exclude responses from inactive users."/>
       </FIELDS>
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -980,6 +980,21 @@ function xmldb_questionnaire_upgrade($oldversion=0) {
         upgrade_mod_savepoint(true, 2020062301, 'questionnaire');
     }
 
+    if ($oldversion < 2020062302) {
+
+        // Define field excludeinactive to be added to questionnaire.
+        $table = new xmldb_table('questionnaire');
+        $field = new xmldb_field('excludeinactive', XMLDB_TYPE_INTEGER, '1', null, XMLDB_NOTNULL, null, 0, 'resp_view');
+
+        // Conditionally launch add field.
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        // Questionnaire savepoint reached.
+        upgrade_mod_savepoint(true, 2020062302, 'questionnaire');
+    }
+
     return $result;
 }
 

--- a/lang/en/questionnaire.php
+++ b/lang/en/questionnaire.php
@@ -125,6 +125,8 @@ $string['dateformatting'] = 'Use the year-month-day format, e.g. for March 4th, 
 // Prior to release 3.6.0, you could specify an input date format in the above string. Now, the format must be as below. This
 // string is used now in case sites modified the above string.
 $string['strictdateformatting'] = 'Use the year-month-day format, e.g. for March 4th, 1945:&nbsp; <strong>1945-03-04</strong>';
+$string['defaultexcludeinactive'] = 'Exclude inactive users\' responses by default';
+$string['defaultexcludeinactive_desc'] = 'By default, should responses from users with inactive or suspended enrolments be excluded from reports?';
 $string['deleteallresponses'] = 'Delete ALL Responses';
 $string['deletecurrentquestion'] = 'Delete question {$a}';
 $string['deletedallgroupresp'] = 'Deleted ALL Responses in group {$a}';
@@ -187,6 +189,8 @@ $string['event_response_deleted'] = 'Individual Response deleted';
 $string['event_resumed'] = 'Attempt resumed';
 $string['event_saved'] = 'Responses saved';
 $string['event_submitted'] = 'Responses submitted';
+$string['excludeinactive'] = 'Exclude inactive users\' responses';
+$string['excludeinactive_help'] = 'Should responses from users with inactive or suspended enrolments be excluded from reports?<br>Note: this option will also exclude any responses from users with only non-student roles, such as teachers.';
 $string['feedback'] = 'Feedback';
 $string['feedback_help'] = 'Feedback Help';
 $string['feedback_link'] = 'mod/questionnaire/personality_test#Editing_Questionnaire_Feedback_Messages';

--- a/mod_form.php
+++ b/mod_form.php
@@ -76,6 +76,10 @@ class mod_questionnaire_mod_form extends moodleform_mod {
         $mform->addElement('select', 'resp_view', get_string('responseview', 'questionnaire'), $questionnaireresponseviewers);
         $mform->addHelpButton('resp_view', 'responseview', 'questionnaire');
 
+        $mform->addElement('selectyesno', 'excludeinactive', get_string('excludeinactive', 'questionnaire'));
+        $mform->addHelpButton('excludeinactive', 'excludeinactive', 'questionnaire');
+        $mform->setDefault('excludeinactive', get_config('questionnaire', 'defaultexcludeinactive'));
+
         $notificationoptions = array(0 => get_string('no'), 1 => get_string('notificationsimple', 'questionnaire'),
             2 => get_string('notificationfull', 'questionnaire'));
         $mform->addElement('select', 'notifications', get_string('notifications', 'questionnaire'), $notificationoptions);

--- a/questionnaire.class.php
+++ b/questionnaire.class.php
@@ -751,6 +751,15 @@ class questionnaire {
         if ($userid) {
             $sql .= ' AND r.userid = :userid';
             $params['userid'] = $userid;
+        } else if (!empty($this->excludeinactive)) {
+            if ($users = get_enrolled_users($this->context, 'mod/questionnaire:submit', $groupid, 'u.id', null, 0, 0, true)) {
+                $userids = array_map(function($u) {
+                    return $u->id;
+                }, $users);
+                list($usersql, $userparams) = $DB->get_in_or_equal($userids, SQL_PARAMS_NAMED);
+                $sql .= " AND r.userid $usersql";
+                $params = array_merge($params, $userparams);
+            }
         }
         return $DB->count_records_sql($sql, $params);
     }
@@ -797,6 +806,15 @@ class questionnaire {
         if ($userid) {
             $sql .= ' AND r.userid = :userid';
             $params['userid'] = $userid;
+        } else if (!empty($this->excludeinactive)) {
+            if ($users = get_enrolled_users($this->context, 'mod/questionnaire:submit', $groupid, 'u.id', null, 0, 0, true)) {
+                $userids = array_map(function($u) {
+                    return $u->id;
+                }, $users);
+                list($usersql, $userparams) = $DB->get_in_or_equal($userids, SQL_PARAMS_NAMED);
+                $sql .= " AND r.userid $usersql";
+                $params = array_merge($params, $userparams);
+            }
         }
 
         $sql .= ' ORDER BY r.id';
@@ -2846,7 +2864,8 @@ class questionnaire {
                 continue;
             }
             $allresponsessql .= $allresponsessql == '' ? '' : ' UNION ALL ';
-            list ($sql, $params) = $question->responsetype->get_bulk_sql($qids, $rid, $userid, $groupid, $showincompletes);
+            list ($sql, $params) = $question->responsetype->get_bulk_sql($qids, $rid, $userid, $groupid, $showincompletes,
+                    !empty($this->excludeinactive), $this->context);
             $allresponsesparams = array_merge($allresponsesparams, $params);
             $allresponsessql .= $sql;
         }

--- a/settings.php
+++ b/settings.php
@@ -56,4 +56,12 @@ if ($ADMIN->fulltree) {
 
     $settings->add(new admin_setting_configcheckbox('questionnaire/allowemailreporting',
         get_string('configemailreporting', 'questionnaire'), get_string('configemailreportinglong', 'questionnaire'), 0));
+
+    $name = get_string('defaultexcludeinactive', 'questionnaire');
+    $desc = get_string('defaultexcludeinactive_desc', 'questionnaire');
+    $options = array(
+        0 => get_string('no'),
+        1 => get_string('yes')
+    );
+    $settings->add(new admin_setting_configselect('questionnaire/defaultexcludeinactive', $name, $desc, 0, $options));
 }

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version  = 2020062301;  // The current module version (Date: YYYYMMDDXX)
+$plugin->version  = 2020062302;  // The current module version (Date: YYYYMMDDXX)
 $plugin->requires = 2020061500; // Moodle version (3.6).
 
 $plugin->component = 'mod_questionnaire';


### PR DESCRIPTION
This commit adds the option to exclude inactive users' responses from questionnaire reports.

New pull request against MOODLE_39_STABLE as per Mike's request at https://github.com/PoetOS/moodle-mod_questionnaire/pull/133#issuecomment-649733335.