### PR TITLE
Bugfix: set course questionnairename if survey is public

### DIFF
--- a/questionnaire.class.php
+++ b/questionnaire.class.php
@@ -2922,9 +2922,10 @@ class questionnaire {
         if (!$this->survey_is_public()) {
             $courseid = $this->course->id;
             $coursename = $this->course->fullname;
+            $modulename = $this->name;
         } else {
             // For a public questionnaire, look for the course that used it.
-            $sql = 'SELECT q.id, q.course, c.fullname ' .
+            $sql = 'SELECT q.id, q.course, q.name, c.fullname ' .
                    'FROM {questionnaire_response} qr ' .
                    'INNER JOIN {questionnaire} q ON qr.questionnaireid = q.id ' .
                    'INNER JOIN {course} c ON q.course = c.id ' .
@@ -2932,9 +2933,11 @@ class questionnaire {
             if ($record = $DB->get_record_sql($sql, [$resprow->rid, 'y'])) {
                 $courseid = $record->course;
                 $coursename = $record->fullname;
+                $modulename = $record->name;
             } else {
                 $courseid = $this->course->id;
                 $coursename = $this->course->fullname;
+                $modulename = $this->name;
             }
         }
 


### PR DESCRIPTION
Hi @mchurchward 

Here was a bug, that when the survey was public, always the survey's modulename was set. But instead we want to set the questionnaire name within each course as modulename, if we're on survey public mode.

HTH,
Adrian