### PR TITLE
Bugfix: add complete row if including incomplete responses

### DIFF
--- a/templates/extrafields.mustache
+++ b/templates/extrafields.mustache
@@ -25,4 +25,5 @@
     }}
 <input type="checkbox" name="choicecodes" id="choicecodes" checked="checked" value="1" /> <label for="choicecodes">{{#str}}includechoicecodes, questionnaire{{/str}}</label><br />
 <input type="checkbox" name="choicetext" id="choicetext" checked="checked" value="1" /> <label for="choicetext">{{#str}}includechoicetext, questionnaire{{/str}}</label><br />
+<input type="checkbox" name="complete" id="complete" value="1" /> <label for="complete">{{#str}}includeincomplete, questionnaire{{/str}}</label><br />
 <input type="checkbox" name="rankaverages" id="rankaverages" value="1" /> <label for="rankaverages">{{#str}}includerankaverages, questionnaire{{/str}}</label><br />


### PR DESCRIPTION
Fixes regression of commit https://github.com/PoetOS/moodle-mod_questionnaire/commit/9d4a078379ddd41c56c7d83843f066a979f88e26

Why did you delete this complete field? As now it will always be false (0) and therefore this row is never included in the export.

HTH,
Adrian