### PR TITLE
Enable horizontal resize

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -388,3 +388,8 @@ td.selected {
 .qn-indent {
     margin-left: 20px;
 }
+     
+#page-mod-questionnaire-questions #fitem_id_allchoices #id_allchoices,
+#page-mod-questionnaire-questions #fitem_id_allnameddegrees #id_allnameddegrees {
+    resize: both;    
+}


### PR DESCRIPTION
When editing a question with Possible answers or/and Named degrees  fields, longish lines do not fit in the cramped width provided. This proposed fix adds a rule to the styles.css file to enable both horizontal and vertical resize of those fields.