### PR TITLE
Stop escaping of text that has been run through the filters as html

### DIFF
--- a/templates/results_choice.mustache
+++ b/templates/results_choice.mustache
@@ -87,7 +87,7 @@
 {{#responses}}
     {{#response}}
     <tr class="">
-        <td class="cell c0" style="text-align:left;width:50%;">{{response.text}}</td>
+        <td class="cell c0" style="text-align:left;width:50%;">{{{response.text}}}</td>
         <td class="cell c1" style="text-align:left;width:40%;white-space:nowrap;">
             <img style="height:9px; width:4px;" alt="{{response.alt1}}" src="{{response.image1}}" /><img style="height:9px; width:{{response.width2}}px;" alt="{{response.alt2}}" src="{{response.image2}}" /><img style="height:9px; width:4px;" alt="{{response.alt3}}" src="{{response.image3}}" />
             {{{response.percent}}}


### PR DESCRIPTION
The mustache variable that I've marked as not needing escaping is a bit of text that gets run through text filters and could end up with html in.