### PR TITLE
Fix for essay question using atto editor

### DIFF
--- a/classes/question/essay.php
+++ b/classes/question/essay.php
@@ -90,7 +90,7 @@ class essay extends text {
             $editor = editors_get_preferred_editor();
             $editor->use_editor($name, questionnaire_get_editor_options($this->context));
             $texteditor = html_writer::tag('textarea', $value,
-                            array('id' => $name, 'name' => $name, 'rows' => $rows, 'cols' => $cols));
+                            array('id' => $name, 'name' => $name, 'rows' => $rows, 'cols' => $cols, 'class'=>'form-control'));
         } else {
             $editor = FORMAT_PLAIN;
             $texteditor = html_writer::tag('textarea', $value,


### PR DESCRIPTION
We noticed that when using the Atto editor for essay questions the border is missing around the text box. When comparing to other Atto editors, we noticed that the form-control class was missing in the editor call. This class works with Atto's css to create the thin border around the editor, with a couple other sizing items. Upon adding the class no other issues where found, and it seems to work still with Tinymce. All and all just a small change.

Hope this helps!