### PR TITLE
Users should be able to print their own response

### DIFF
--- a/report.php
+++ b/report.php
@@ -78,7 +78,9 @@ if ($outputtarget == 'pdf') {
 
 // If you can't view the questionnaire, or can't view a specified response, error out.
 $context = context_module::instance($cm->id);
-if (!$questionnaire->can_view_all_responses()) {
+$responseisviewable = $rid == 0 || $questionnaire->can_view_response($rid);
+$canviewthisresponse = $questionnaire->capabilities->view && $responseisviewable;
+if (!$questionnaire->can_view_all_responses() && !$canviewthisresponse) {
     // Should never happen, unless called directly by a snoop...
     print_error('nopermissions', 'moodle', $CFG->wwwroot.'/mod/questionnaire/view.php?id='.$cm->id,
         get_string('viewallresponses', 'mod_questionnaire'));

--- a/tests/behat/check_responses_capabilities.feature
+++ b/tests/behat/check_responses_capabilities.feature
@@ -99,3 +99,39 @@ Feature: Review responses with different capabilities
     And I follow "Test questionnaire 2"
     Then I should see "View All Responses"
     And I log out
+
+  @javascript
+  Scenario: A student can see their own responses after submit the response.
+    Given the following "users" exist:
+      | username | firstname | lastname | email                |
+      | teacher1 | Teacher   | 1        | teacher1@example.com |
+      | student1 | Student   | 1        | student1@example.com |
+    And the following "courses" exist:
+      | fullname | shortname | category |
+      | Course 1 | C1        | 0        |
+    And the following "course enrolments" exist:
+      | user     | course | role           |
+      | student1 | C1     | student        |
+    And I log in as "admin"
+    And the following "activities" exist:
+      | activity      | name               | description                    | course | idnumber       | resp_view |
+      | questionnaire | Test questionnaire | Test questionnaire description | C1     | questionnaire0 | 0         |
+    And I am on "Course 1" course homepage
+    And I follow "Test questionnaire"
+    And I navigate to "Questions" in current page administration
+    And I add a "Yes/No" question and I fill the form with:
+      | Question Name | Q9 |
+      | Yes | y |
+      | Question Text | Choose yes or no |
+    And I log out
+    And I log in as "student1"
+    And I am on "Course 1" course homepage
+    And I follow "Test questionnaire"
+    Then I should not see "View All Responses"
+    And I navigate to "Answer the questions..." in current page administration
+    And I set the field "Yes" to "checked"
+    And I press "Submit questionnaire"
+    And I press "Continue"
+    And I follow "Print this Response"
+    And I should see "Test questionnaire"
+    


### PR DESCRIPTION
Hi @mchurchward ,
When our teacher set the response option "Student print nopermission" to "Never".
Our student can't print their own response when clicking the print button.
So I'm updating the logic for the permission.
Could you please review and give me your thoughts on the changes.
