### PR TITLE
Questionnaire: Inconsistent advice on 'Date' question #447472

### DIFF
--- a/lang/en/questionnaire.php
+++ b/lang/en/questionnaire.php
@@ -123,7 +123,7 @@ $string['date_link'] = 'mod/questionnaire/questions#Date';
 $string['dateformatting'] = 'Use the year-month-day format, e.g. for March 4th, 1945:&nbsp; <strong>1945-03-04</strong>';
 // Prior to release 3.6.0, you could specify an input date format in the above string. Now, the format must be as below. This
 // string is used now in case sites modified the above string.
-$string['strictdateformatting'] = 'Enter the date using the date picker below, or by using the \'YYYY-MM-DD\' format.';
+$string['strictdateformatting'] = 'Enter the date using the date picker below.';
 $string['deleteallresponses'] = 'Delete ALL Responses';
 $string['deletecurrentquestion'] = 'Delete question {$a}';
 $string['deletedallgroupresp'] = 'Deleted ALL Responses in group {$a}';


### PR DESCRIPTION
We are from the Open University and would like to do this change:

- The advice text is "Enter the date using the date picker below, or by using the 'YYY-MM-DD' format": we will change the current text to simply "Enter the date using the date picker below", because then the wording works with whatever date format setting, and the date format displays in the box anyway.

Please help me review it.

Many thanks.