### PR TITLE
Fix feedback section errors when scorecalculation is empty

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,26 +8,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - php: '7.4'
-            moodle-branch: 'MOODLE_311_STABLE'
-            database: 'mariadb'
-            node: '14.15.0'
-          - php: '7.3'
-            moodle-branch: 'MOODLE_310_STABLE'
-            database: 'mariadb'
-            node: '14.15.0'
-          - php: '7.4'
-            moodle-branch: 'MOODLE_311_STABLE'
+          - php: '8.0'
+            moodle-branch: 'master'
             database: 'pgsql'
-            node: '14.15.0'
-          - php: '7.2'
-            moodle-branch: 'MOODLE_39_STABLE'
-            database: 'pgsql'
-            node: '14.15.0'
+          - php: '7.4'
+            moodle-branch: 'master'
+            database: 'mariadb'
 
     services:
       postgres:
-        image: postgres
+        image: postgres:10
         env:
           POSTGRES_USER: 'postgres'
           POSTGRES_HOST_AUTH_METHOD: 'trust'
@@ -40,10 +30,12 @@ jobs:
           - 5432:5432
 
       mariadb:
-        image: mariadb:10.5
+        image: mariadb:10
         env:
           MYSQL_USER: 'root'
           MYSQL_ALLOW_EMPTY_PASSWORD: "true"
+          MYSQL_CHARACTER_SET_SERVER: "utf8mb4"
+          MYSQL_COLLATION_SERVER: "utf8mb4_unicode_ci"
         ports:
           - 3306:3306
         options: --health-cmd="mysqladmin ping" --health-interval 10s --health-timeout 5s --health-retries 3
@@ -54,16 +46,13 @@ jobs:
         with:
           path: plugin
 
-      - name: Install node
-        uses: actions/setup-node@v1
-        with:
-          node-version: ${{ matrix.node }}
-
-      - name: Setup PHP
+      - name: Setup PHP ${{ matrix.php }}
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: zip, gd, mbstring, pgsql, mysqli
+          extensions: ${{ matrix.extensions }}
+          ini-values: max_input_vars=5000
+          coverage: none
 
       - name: Deploy moodle-plugin-ci
         run: |
@@ -73,51 +62,58 @@ jobs:
           echo $(cd ci/vendor/bin; pwd) >> $GITHUB_PATH
           # PHPUnit depends on en_AU.UTF-8 locale
           sudo locale-gen en_AU.UTF-8
+          echo "NVM_DIR=$HOME/.nvm" >> $GITHUB_ENV
+
       - name: Install Moodle
         # Need explicit IP to stop mysql client fail on attempt to use unix socket.
         run: moodle-plugin-ci install --plugin ./plugin --db-host=127.0.0.1
         env:
           DB: ${{ matrix.database }}
           MOODLE_BRANCH: ${{ matrix.moodle-branch }}
-          IGNORE_NAMES: 'mobile_*.mustache'
           IGNORE_PATHS: 'templates/local/mobile'
 
-      - name: phplint
+      - name: PHP Lint
         if: ${{ always() }}
         run: moodle-plugin-ci phplint
 
-      - name: phpcpd
+      - name: PHP Copy/Paste Detector
+        continue-on-error: true # This step will show errors but will not fail
         if: ${{ always() }}
-        run: moodle-plugin-ci phpcpd || true
+        run: moodle-plugin-ci phpcpd
 
-      - name: phpmd
+      - name: PHP Mess Detector
+        continue-on-error: true # This step will show errors but will not fail
         if: ${{ always() }}
         run: moodle-plugin-ci phpmd
 
-      - name: codechecker
+      - name: Moodle Code Checker
         if: ${{ always() }}
         run: moodle-plugin-ci codechecker
 
-      - name: validate
+      - name: Moodle PHPDoc Checker
+        if: ${{ always() }}
+        run: moodle-plugin-ci phpdoc
+
+      - name: Validating
         if: ${{ always() }}
         run: moodle-plugin-ci validate
 
-      - name: savepoints
+      - name: Check upgrade savepoints
         if: ${{ always() }}
         run: moodle-plugin-ci savepoints
 
-      - name: mustache
+      - name: Mustache Lint
         if: ${{ always() }}
         run: moodle-plugin-ci mustache
 
-      - name: grunt
+      - name: Grunt
         if: ${{ always() }}
-        run: moodle-plugin-ci grunt
+        run: moodle-plugin-ci grunt --max-lint-warnings 0
 
-      - name: phpunit
+      - name: PHPUnit tests
         if: ${{ always() }}
         run: moodle-plugin-ci phpunit
 
-      - name: behat
+      - name: Behat features
         if: ${{ always() }}
         run: moodle-plugin-ci behat --profile chrome

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,16 +1,5 @@
 Release Notes
 
-_NOTE - The 3.10 releases will work on Moodle 3.9, Moodle 3.10, and Moodle 3.11.
+Version 4.0.0 Beta (Build - 2022030400)
 
-##### Version 3.10.1 (Build - 2021080400)
-Bug fixes:
-* GHI353 Ensuring clean text on new and existing essay questions.
-* GHI319 Fixing question preview display.
-* GHP321 Added CSS rule to styles.css to enable horizontal and vertical resize.
-* GHI351 Ignore deleted questions but continue loop over remaining responses.
-
-##### Version 3.10.0 (Build - 2020111100)
-Improvements:
-* Setup for 3.11 compliance as well.
-
-(see CHANGES.TXT in release 3.9 for earlier changes.)
+(see CHANGES.md in release 3.11 for earlier changes.)

--- a/backup/moodle1/lib.php
+++ b/backup/moodle1/lib.php
@@ -17,8 +17,7 @@
 /**
  * Provides support for the conversion of moodle1 backup to the moodle2 format
  *
- * @package    mod
- * @subpackage questionnaire
+ * @package    mod_questionnaire
  * @copyright  2011 Robin de Vries <robin@celp.nl>
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
@@ -33,7 +32,7 @@ class moodle1_mod_questionnaire_handler extends moodle1_mod_handler {
     /**
      * Declare the paths in moodle.xml we are able to convert
      *
-     * The method returns list of {@link convert_path} instances. For each path returned,
+     * The method returns list of convert_path instances. For each path returned,
      * at least one of on_xxx_start(), process_xxx() and on_xxx_end() methods must be
      * defined. The method process_xxx() is not executed if the associated path element is
      * empty (i.e. it contains none elements or sub-paths only).
@@ -42,7 +41,7 @@ class moodle1_mod_questionnaire_handler extends moodle1_mod_handler {
      * actually exist in the file. The last element with the module name was
      * appended by the moodle1_converter class.
      *
-     * @return array of {@link convert_path} instances
+     * @return array of convert_path instances
      */
     public function get_paths() {
         return array(
@@ -62,9 +61,11 @@ class moodle1_mod_questionnaire_handler extends moodle1_mod_handler {
             new convert_path('question_choice', '/MOODLE_BACKUP/COURSE/MODULES/MOD/QUESTIONNAIRE/SURVEY/QUESTION/QUESTION_CHOICE'),
         );
     }
+
     /**
      * This is executed every time we have one /MOODLE_BACKUP/COURSE/MODULES/MOD/QUESTIONNAIRE
-     * data available
+     * data available.
+     * @param array $data
      */
     public function process_questionnaire($data) {
         // Get the course module id and context id.
@@ -88,7 +89,6 @@ class moodle1_mod_questionnaire_handler extends moodle1_mod_handler {
     /**
      * This is executed when we reach the closing </MOD> tag of our 'questionnaire' path
      */
-
     public function on_questionnaire_end() {
         // Close questionnaire.xml.
         $this->xmlwriter->end_tag('surveys');
@@ -96,9 +96,11 @@ class moodle1_mod_questionnaire_handler extends moodle1_mod_handler {
         $this->xmlwriter->end_tag('activity');
         $this->close_xml_writer();
     }
+
     /**
      * This is executed every time we have one /MOODLE_BACKUP/COURSE/MODULES/MOD/QUESTIONNAIRE/SURVEY
      * data available
+     * @param array $data
      */
     public function process_survey($data) {
         $this->xmlwriter->begin_tag('survey', array('id' => $data['id']));
@@ -120,6 +122,7 @@ class moodle1_mod_questionnaire_handler extends moodle1_mod_handler {
     /**
      * This is executed every time we have one /MOODLE_BACKUP/COURSE/MODULES/MOD/QUESTIONNAIRE/SURVEY/QUESTION
      * data available
+     * @param array $data
      */
     public function process_question($data) {
 
@@ -144,9 +147,9 @@ class moodle1_mod_questionnaire_handler extends moodle1_mod_handler {
     /**
      * This is executed every time we have one /MOODLE_BACKUP/COURSE/MODULES/MOD/QUESTIONNAIRE/SURVEY/QUESTION/QUESTION_CHOICE
      * data available
+     * @param array $data
      */
     public function process_question_choice($data) {
         $this->write_xml('quest_choice', $data, array('/question_choice/id'));
     }
-
 }

--- a/backup/moodle2/backup_questionnaire_activity_task.class.php
+++ b/backup/moodle2/backup_questionnaire_activity_task.class.php
@@ -14,13 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * @package mod_questionnaire
- * @copyright  2016 Mike Churchward (mike.churchward@poetgroup.org)
- * @author     Mike Churchward
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
 defined('MOODLE_INTERNAL') || die();
 
 // Because it exists (must).
@@ -29,8 +22,11 @@ require_once($CFG->dirroot . '/mod/questionnaire/backup/moodle2/backup_questionn
 require_once($CFG->dirroot . '/mod/questionnaire/backup/moodle2/backup_questionnaire_settingslib.php');
 
 /**
- * questionnaire backup task that provides all the settings and steps to perform one
- * complete backup of the activity
+ * Questionnaire backup task that provides all the settings and steps to perform one complete backup of the activity.
+ * @package mod_questionnaire
+ * @copyright  2016 Mike Churchward (mike.churchward@poetgroup.org)
+ * @author     Mike Churchward
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class backup_questionnaire_activity_task extends backup_activity_task {
 
@@ -52,6 +48,8 @@ class backup_questionnaire_activity_task extends backup_activity_task {
     /**
      * Code the transformations to perform in the activity in
      * order to get transportable (encoded) links
+     * @param string $content
+     * @return array|string|string[]|null
      */
     public static function encode_content_links($content) {
         global $CFG;

--- a/backup/moodle2/backup_questionnaire_settingslib.php
+++ b/backup/moodle2/backup_questionnaire_settingslib.php
@@ -15,6 +15,7 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
+ * The required settingslib file.
  * @package mod_questionnaire
  * @copyright  2016 Mike Churchward (mike.churchward@poetgroup.org)
  * @author     Mike Churchward

--- a/backup/moodle2/backup_questionnaire_stepslib.php
+++ b/backup/moodle2/backup_questionnaire_stepslib.php
@@ -14,24 +14,24 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+defined('MOODLE_INTERNAL') || die();
+
 /**
+ * Define all the backup steps that will be used by the backup_questionnaire_activity_task.
+ *
+ * Define the complete choice structure for backup, with file and id annotations.
+ *
  * @package mod_questionnaire
  * @copyright  2016 Mike Churchward (mike.churchward@poetgroup.org)
  * @author     Mike Churchward
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-
-defined('MOODLE_INTERNAL') || die();
-
-/**
- * Define all the backup steps that will be used by the backup_questionnaire_activity_task
- */
-
-/**
- * Define the complete choice structure for backup, with file and id annotations
- */
 class backup_questionnaire_activity_structure_step extends backup_activity_structure_step {
 
+    /**
+     * Defines the backup structure.
+     * @return backup_nested_element
+     */
     protected function define_structure() {
         global $DB;
         // To know if we are including userinfo.

--- a/backup/moodle2/restore_questionnaire_activity_task.class.php
+++ b/backup/moodle2/restore_questionnaire_activity_task.class.php
@@ -14,21 +14,17 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * @package mod_questionnaire
- * @copyright  2016 Mike Churchward (mike.churchward@poetgroup.org)
- * @author     Mike Churchward
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
 defined('MOODLE_INTERNAL') || die();
 
 // Because it exists (must).
 require_once($CFG->dirroot . '/mod/questionnaire/backup/moodle2/restore_questionnaire_stepslib.php');
 
 /**
- * questionnaire restore task that provides all the settings and steps to perform one
- * complete restore of the activity
+ * Questionnaire restore task that provides all the settings and steps to perform one complete restore of the activity.
+ * @package mod_questionnaire
+ * @copyright  2016 Mike Churchward (mike.churchward@poetgroup.org)
+ * @author     Mike Churchward
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class restore_questionnaire_activity_task extends restore_activity_task {
 
@@ -78,9 +74,9 @@ class restore_questionnaire_activity_task extends restore_activity_task {
 
     /**
      * Define the restore log rules that will be applied
-     * by the {@link restore_logs_processor} when restoring
+     * by the restore_logs_processor when restoring
      * questionnaire logs. It must return one array
-     * of {@link restore_log_rule} objects
+     * of restore_log_rule objects
      */
     public static function define_restore_log_rules() {
         $rules = array();
@@ -97,9 +93,9 @@ class restore_questionnaire_activity_task extends restore_activity_task {
 
     /**
      * Define the restore log rules that will be applied
-     * by the {@link restore_logs_processor} when restoring
+     * by the restore_logs_processor when restoring
      * course logs. It must return one array
-     * of {@link restore_log_rule} objects
+     * of restore_log_rule objects
      *
      * Note this rules are applied when restoring course logs
      * by the restore final task, but are defined here at

--- a/backup/moodle2/restore_questionnaire_stepslib.php
+++ b/backup/moodle2/restore_questionnaire_stepslib.php
@@ -14,21 +14,17 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+defined('MOODLE_INTERNAL') || die();
+
 /**
+ * Define all the restore steps that will be used by the restore_questionnaire_activity_task.
+ *
+ * Structure step to restore one questionnaire activity.
+ *
  * @package mod_questionnaire
  * @copyright  2016 Mike Churchward (mike.churchward@poetgroup.org)
  * @author     Mike Churchward
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
-defined('MOODLE_INTERNAL') || die();
-
-/**
- * Define all the restore steps that will be used by the restore_questionnaire_activity_task
- */
-
-/**
- * Structure step to restore one questionnaire activity
  */
 class restore_questionnaire_activity_structure_step extends restore_activity_structure_step {
 
@@ -47,6 +43,10 @@ class restore_questionnaire_activity_structure_step extends restore_activity_str
      */
     protected $olddependencies = [];
 
+    /**
+     * Implementation of define_structure.
+     * @return mixed
+     */
     protected function define_structure() {
 
         $paths = array();
@@ -110,6 +110,10 @@ class restore_questionnaire_activity_structure_step extends restore_activity_str
         return $this->prepare_activity_structure($paths);
     }
 
+    /**
+     * Implementation of process_questionnaire.
+     * @param array $data
+     */
     protected function process_questionnaire($data) {
         global $DB;
 
@@ -126,6 +130,10 @@ class restore_questionnaire_activity_structure_step extends restore_activity_str
         $this->apply_activity_instance($newitemid);
     }
 
+    /**
+     * Process the survey table.
+     * @param array $data
+     */
     protected function process_questionnaire_survey($data) {
         global $DB;
 
@@ -146,6 +154,10 @@ class restore_questionnaire_activity_structure_step extends restore_activity_str
         $DB->set_field('questionnaire', 'sid', $newitemid, array('id' => $this->get_new_parentid('questionnaire')));
     }
 
+    /**
+     * Process the questions.
+     * @param array $data
+     */
     protected function process_questionnaire_question($data) {
         global $DB;
 
@@ -166,9 +178,9 @@ class restore_questionnaire_activity_structure_step extends restore_activity_str
     }
 
     /**
+     * Process the feedback sections.
      * $qid is unused, but is needed in order to get the $key elements of the array. Suppress PHPMD warning.
-     *
-     * @SuppressWarnings(PHPMD.UnusedLocalVariable)
+     * @param array $data
      */
     protected function process_questionnaire_fb_sections($data) {
         global $DB;
@@ -193,6 +205,10 @@ class restore_questionnaire_activity_structure_step extends restore_activity_str
         $this->set_mapping('questionnaire_fb_sections', $oldid, $newitemid, true);
     }
 
+    /**
+     * Process feedback.
+     * @param array $data
+     */
     protected function process_questionnaire_feedback($data) {
         global $DB;
 
@@ -205,6 +221,10 @@ class restore_questionnaire_activity_structure_step extends restore_activity_str
         $this->set_mapping('questionnaire_feedback', $oldid, $newitemid, true);
     }
 
+    /**
+     * Process question choices.
+     * @param array $data
+     */
     protected function process_questionnaire_quest_choice($data) {
         global $CFG, $DB;
 
@@ -234,6 +254,10 @@ class restore_questionnaire_activity_structure_step extends restore_activity_str
         $this->set_mapping('questionnaire_quest_choice', $oldid, $newitemid);
     }
 
+    /**
+     * Process dependencies.
+     * @param array $data
+     */
     protected function process_questionnaire_dependency($data) {
         $data = (object)$data;
 
@@ -245,11 +269,20 @@ class restore_questionnaire_activity_structure_step extends restore_activity_str
         }
     }
 
+    /**
+     * Process attempts (these are no longer used).
+     * @param array $data
+     * @return bool
+     */
     protected function process_questionnaire_attempt($data) {
         // New structure will be completed in process_questionnaire_response. Nothing to do here any more.
         return true;
     }
 
+    /**
+     * Process responses.
+     * @param array $data
+     */
     protected function process_questionnaire_response($data) {
         global $DB;
 
@@ -269,6 +302,11 @@ class restore_questionnaire_activity_structure_step extends restore_activity_str
         $this->set_mapping('questionnaire_response', $oldid, $newitemid);
     }
 
+    /**
+     * Process boolean responses.
+     * @param array $data
+     * @throws dml_exception
+     */
     protected function process_questionnaire_response_bool($data) {
         global $DB;
 
@@ -280,6 +318,11 @@ class restore_questionnaire_activity_structure_step extends restore_activity_str
         $DB->insert_record('questionnaire_response_bool', $data);
     }
 
+    /**
+     * Process date responses.
+     * @param array $data
+     * @throws dml_exception
+     */
     protected function process_questionnaire_response_date($data) {
         global $DB;
 
@@ -291,6 +334,11 @@ class restore_questionnaire_activity_structure_step extends restore_activity_str
         $DB->insert_record('questionnaire_response_date', $data);
     }
 
+    /**
+     * Process multiple responses.
+     * @param array $data
+     * @throws dml_exception
+     */
     protected function process_questionnaire_response_multiple($data) {
         global $DB;
 
@@ -303,6 +351,11 @@ class restore_questionnaire_activity_structure_step extends restore_activity_str
         $DB->insert_record('questionnaire_resp_multiple', $data);
     }
 
+    /**
+     * Process other responses.
+     * @param array $data
+     * @throws dml_exception
+     */
     protected function process_questionnaire_response_other($data) {
         global $DB;
 
@@ -315,6 +368,11 @@ class restore_questionnaire_activity_structure_step extends restore_activity_str
         $DB->insert_record('questionnaire_response_other', $data);
     }
 
+    /**
+     * Process rank responses.
+     * @param array $data
+     * @throws dml_exception
+     */
     protected function process_questionnaire_response_rank($data) {
         global $DB;
 
@@ -333,6 +391,11 @@ class restore_questionnaire_activity_structure_step extends restore_activity_str
         $DB->insert_record('questionnaire_response_rank', $data);
     }
 
+    /**
+     * Process single responses.
+     * @param array $data
+     * @throws dml_exception
+     */
     protected function process_questionnaire_response_single($data) {
         global $DB;
 
@@ -345,6 +408,10 @@ class restore_questionnaire_activity_structure_step extends restore_activity_str
         $DB->insert_record('questionnaire_resp_single', $data);
     }
 
+    /**
+     * Process text answers.
+     * @param array $data
+     */
     protected function process_questionnaire_response_text($data) {
         global $DB;
 
@@ -356,6 +423,9 @@ class restore_questionnaire_activity_structure_step extends restore_activity_str
         $DB->insert_record('questionnaire_response_text', $data);
     }
 
+    /**
+     * Stuff to do after execution.
+     */
     protected function after_execute() {
         global $DB;
 

--- a/classes/db/bulk_sql_config.php
+++ b/classes/db/bulk_sql_config.php
@@ -53,6 +53,7 @@ class bulk_sql_config {
     protected $userank = false;
 
     /**
+     * The class constructor.
      * @param string $table
      * @param string $tablealias
      * @param bool $usechoiceid

--- a/classes/edit_question_form.php
+++ b/classes/edit_question_form.php
@@ -15,11 +15,11 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
+ * The form class for editing questions.
  * @package mod_questionnaire
  * @copyright  2016 Mike Churchward (mike.churchward@poetgroup.org)
  * @author Mike Churchward & Joseph Rézeau
  * @license http://www.gnu.org/copyleft/gpl.html GNU Public License
- * @package questionnaire
  */
 
 namespace mod_questionnaire;
@@ -36,6 +36,9 @@ require_once($CFG->libdir . '/formslib.php');
  */
 class edit_question_form extends \moodleform {
 
+    /**
+     * Form definition.
+     */
     public function definition() {
         // TODO - Find a way to not use globals. Maybe the base class allows more parameters to be passed?
         global $questionnaire, $question, $SESSION;
@@ -55,6 +58,14 @@ class edit_question_form extends \moodleform {
         }
     }
 
+    /**
+     * Form validation.
+     *
+     * @param array $data array of ("fieldname"=>value) of submitted data
+     * @param array $files array of uploaded files "element_name"=>tmp_file_path
+     * @return array of "element_name"=>"error_description" if there are errors,
+     *         or an empty array if everything is OK (true allowed for backwards compatibility too).
+     */
     public function validation($data, $files) {
         $errors = parent::validation($data, $files);
 
@@ -86,7 +97,6 @@ class edit_question_form extends \moodleform {
      * Magic method for getting the protected $_form MoodleQuickForm and $_customdata array properties.
      * @param string $name
      * @return mixed
-     * @throws \coding_exception
      */
     public function __get($name) {
         if ($name == '_form') {

--- a/classes/event/question_created.php
+++ b/classes/event/question_created.php
@@ -14,38 +14,25 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * The mod_questionnaire question_created event.
- *
- * @package    mod_questionnaire
- * @copyright  2014 Joseph Rézeau <moodle@rezeau.org>
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
 namespace mod_questionnaire\event;
-
-defined('MOODLE_INTERNAL') || die();
 
 /**
  * The mod_questionnaire question_created event class.
  *
  * @package    mod_questionnaire
- * @since      Moodle 2.7
  * @copyright  2014 Joseph Rézeau <moodle@rezeau.org>
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-
 class question_created extends \core\event\base {
-    /*
+    /**
      * Set basic properties for the event.
      */
-
     protected function init() {
         $this->data['crud'] = 'c';
         $this->data['edulevel'] = self::LEVEL_TEACHING;
     }
 
-    /*
+    /**
      * Return localised event name.
      *
      * @return string
@@ -54,7 +41,7 @@ class question_created extends \core\event\base {
         return get_string('event_question_created', 'mod_questionnaire');
     }
 
-    /*
+    /**
      * Returns description of what happened.
      *
      * @return string

--- a/classes/event/question_deleted.php
+++ b/classes/event/question_deleted.php
@@ -14,39 +14,25 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * The mod_questionnaire question_deleted event.
- *
- * @package    mod_questionnaire
- * @copyright  2014 Joseph Rézeau <moodle@rezeau.org>
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
 namespace mod_questionnaire\event;
-
-defined('MOODLE_INTERNAL') || die();
 
 /**
  * The mod_questionnaire question_deleted event class.
  *
  * @package    mod_questionnaire
- * @since      Moodle 2.7
  * @copyright  2014 Joseph Rézeau <moodle@rezeau.org>
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-
-
 class question_deleted extends \core\event\base {
-    /*
+    /**
      * Set basic properties for the event.
      */
-
     protected function init() {
         $this->data['crud'] = 'd';
         $this->data['edulevel'] = self::LEVEL_TEACHING;
     }
 
-    /*
+    /**
      * Return localised event name.
      *
      * @return string
@@ -55,7 +41,7 @@ class question_deleted extends \core\event\base {
         return get_string('event_question_deleted', 'mod_questionnaire');
     }
 
-    /*
+    /**
      * Returns description of what happened.
      *
      * @return string

--- a/classes/feedback/section.php
+++ b/classes/feedback/section.php
@@ -58,13 +58,13 @@ class section {
      *  'surveyid' - the surveyid field of the fb_sections table (required if no 'id' field),
      *  'sectionnum' - the section field of the fb_sections table (ignored if 'id' is present; defaults to 1).
      *
-     * @param array $params As above
      * @param array $questions Array of mod_questionnaire\question objects.
+     * @param array $params As above
      * @throws \dml_exception
      * @throws coding_exception
      * @throws invalid_parameter_exception
      */
-    public function __construct($params = [], $questions) {
+    public function __construct($questions, $params = []) {
 
         if (!is_array($params) || !is_array($questions)) {
             throw new coding_exception('Invalid data provided.');

--- a/classes/feedback/section.php
+++ b/classes/feedback/section.php
@@ -97,7 +97,7 @@ class section {
         $newsection->surveyid = $surveyid;
         $newsection->section = $maxsection + 1;
         $newsection->sectionlabel = $sectionlabel;
-        $newsection->scorecalculation = '';
+        $newsection->scorecalculation = self::encode_scorecalculation([]);
         $newsecid = $DB->insert_record(self::TABLE, $newsection);
         $newsection->id = $newsecid;
         $newsection->scorecalculation = [];

--- a/classes/feedback/section.php
+++ b/classes/feedback/section.php
@@ -14,17 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * Manage feedback sections.
- *
- * @package    mod_questionnaire
- * @copyright  2018 onward Mike Churchward (mike.churchward@poetopensource.org)
- * @author     Mike Churchward
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
 namespace mod_questionnaire\feedback;
-defined('MOODLE_INTERNAL') || die();
 
 use invalid_parameter_exception;
 use coding_exception;
@@ -32,23 +22,35 @@ use coding_exception;
 /**
  * Class for describing a feedback section.
  *
- * @author Mike Churchward
- * @package feedback
+ * @package    mod_questionnaire
+ * @copyright  2018 onward Mike Churchward (mike.churchward@poetopensource.org)
+ * @author     Mike Churchward
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-
 class section {
 
+    /** @var int */
     public $id = 0;
+    /** @var int */
     public $surveyid = 0;
+    /** @var int */
     public $section = 1;
+    /** @var array */
     public $scorecalculation = [];
+    /** @var string */
     public $sectionlabel = '';
+    /** @var string */
     public $sectionheading = '';
+    /** @var string */
     public $sectionheadingformat = FORMAT_HTML;
+    /** @var array */
     public $sectionfeedback = [];
+    /** @var array */
     public $questions = [];
 
+    /** The table name. */
     const TABLE = 'questionnaire_fb_sections';
+    /** Represents the "no score" setting. */
     const NOSCORE = -1;
 
     /**
@@ -80,7 +82,9 @@ class section {
 
     /**
      * Factory method to create a new, empty section and return an instance.
-     *
+     * @param int $surveyid
+     * @param string $sectionlabel
+     * @return section
      */
     public static function new_section($surveyid, $sectionlabel = '') {
         global $DB;
@@ -154,11 +158,8 @@ class section {
     /**
      * Loads the section feedback record into the proper array location.
      *
-     * @param $feedbackrec
+     * @param \stdClass $feedbackrec
      * @return int The id of the section feedback record.
-     * @throws \dml_exception
-     * @throws coding_exception
-     * @throws invalid_parameter_exception
      */
     public function load_sectionfeedback($feedbackrec) {
         if (!isset($feedbackrec->id) || empty($feedbackrec->id)) {
@@ -174,8 +175,7 @@ class section {
     /**
      * Updates the object and data record with a new scorecalculation. If no new score provided, uses what's in the object.
      *
-     * @param $scorecalculation
-     * @throws \dml_exception
+     * @param array $scorecalculation
      * @throws coding_exception
      */
     public function set_new_scorecalculation($scorecalculation = null) {
@@ -261,6 +261,7 @@ class section {
     }
 
     /**
+     * Return the decoded calculation array/
      * @param string $codedstring
      * @return mixed
      * @throws coding_exception
@@ -292,6 +293,7 @@ class section {
     }
 
     /**
+     * Return the encoded score array as a serialized string.
      * @param string $scorearray
      * @return mixed
      * @throws coding_exception

--- a/classes/feedback/sectionfeedback.php
+++ b/classes/feedback/sectionfeedback.php
@@ -14,17 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * Manage feedback sections.
- *
- * @package    mod_questionnaire
- * @copyright  2018 onward Mike Churchward (mike.churchward@poetopensource.org)
- * @author     Mike Churchward
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
 namespace mod_questionnaire\feedback;
-defined('MOODLE_INTERNAL') || die();
 
 use invalid_parameter_exception;
 use coding_exception;
@@ -32,28 +22,34 @@ use coding_exception;
 /**
  * Class for describing a feedback section's feedback definition.
  *
- * @author Mike Churchward
- * @package feedback
+ * @package    mod_questionnaire
+ * @copyright  2018 onward Mike Churchward (mike.churchward@poetopensource.org)
+ * @author     Mike Churchward
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-
 class sectionfeedback {
-
+    /** @var int */
     public $id = 0;
+    /** @var int */
     public $sectionid = 0;
+    /** @var string */
     public $feedbacklabel = ''; // I don't think this is actually used?
+    /** @var string */
     public $feedbacktext = '';
+    /** @var string */
     public $feedbacktextformat = FORMAT_HTML;
+    /** @var float */
     public $minscore = 0.0;
+    /** @var float */
     public $maxscore = 0.0;
 
+    /** The table name. */
     const TABLE = 'questionnaire_feedback';
 
     /**
+     * Class constructor.
      * @param int $id
      * @param null|object $record
-     * @throws \dml_exception
-     * @throws coding_exception
-     * @throws invalid_parameter_exception
      */
     public function __construct($id = 0, $record = null) {
         // Return a new section based on the data id.
@@ -70,7 +66,8 @@ class sectionfeedback {
 
     /**
      * Factory method to create a new sectionfeedback from the provided data and return an instance.
-     *
+     * @param \stdClass $data
+     * @return sectionfeedback
      */
     public static function new_sectionfeedback($data) {
         global $DB;
@@ -99,9 +96,9 @@ class sectionfeedback {
     }
 
     /**
-     * @param $id
+     * Return the record specified by the id.
+     * @param int $id
      * @return mixed
-     * @throws \dml_exception
      */
     protected function get_sectionfeedback($id) {
         global $DB;

--- a/classes/feedback_form.php
+++ b/classes/feedback_form.php
@@ -14,6 +14,13 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+namespace mod_questionnaire;
+
+defined('MOODLE_INTERNAL') || die();
+
+require_once($CFG->libdir . '/formslib.php');
+require_once($CFG->dirroot.'/mod/questionnaire/lib.php');
+
 /**
  * Print the form to manage feedback settings.
  *
@@ -22,16 +29,11 @@
  * @author Joseph Rezeau
  * @license http://www.gnu.org/copyleft/gpl.html GNU Public License
  */
-
-namespace mod_questionnaire;
-
-defined('MOODLE_INTERNAL') || die();
-
-require_once($CFG->libdir . '/formslib.php');
-require_once($CFG->dirroot.'/mod/questionnaire/lib.php');
-
 class feedback_form extends \moodleform {
 
+    /**
+     * Defition of the form.
+     */
     public function definition() {
         global $questionnaire;
 
@@ -130,6 +132,12 @@ class feedback_form extends \moodleform {
         }
     }
 
+    /**
+     * Validate the data submitted.
+     * @param array $data
+     * @param array $files
+     * @return array
+     */
     public function validation($data, $files) {
         $errors = parent::validation($data, $files);
         return $errors;

--- a/classes/feedback_section_form.php
+++ b/classes/feedback_section_form.php
@@ -14,6 +14,13 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+namespace mod_questionnaire;
+
+defined('MOODLE_INTERNAL') || die();
+
+require_once($CFG->libdir . '/formslib.php');
+require_once($CFG->dirroot.'/mod/questionnaire/lib.php');
+
 /**
  * Print the form to add or edit a questionnaire-instance
  *
@@ -22,18 +29,14 @@
  * @author Joseph Rezeau (based on Quiz by Tim Hunt)
  * @license http://www.gnu.org/copyleft/gpl.html GNU Public License
  */
-
-namespace mod_questionnaire;
-
-defined('MOODLE_INTERNAL') || die();
-
-require_once($CFG->libdir . '/formslib.php');
-require_once($CFG->dirroot.'/mod/questionnaire/lib.php');
-
 class feedback_section_form extends \moodleform {
 
+    /** @var mixed $_feedbacks */
     protected $_feedbacks;
 
+    /**
+     * Form definition.
+     */
     public function definition() {
         global $questionnaire;
 
@@ -175,6 +178,10 @@ class feedback_section_form extends \moodleform {
         $mform->closeHeaderBefore('buttonar');
     }
 
+    /**
+     * Form preprocessing.
+     * @param array $toform
+     */
     public function data_preprocessing(&$toform) {
         if (count($this->_feedbacks)) {
             $key = 0;
@@ -200,6 +207,13 @@ class feedback_section_form extends \moodleform {
             }
         }
     }
+
+    /**
+     * Form validation.
+     * @param array $data
+     * @param array $files
+     * @return array
+     */
     public function validation($data, $files) {
         $errors = parent::validation($data, $files);
 
@@ -250,7 +264,7 @@ class feedback_section_form extends \moodleform {
      * form definition (new entry form); this function is used to load in data where values
      * already exist and data is being edited (edit entry form).
      *
-     * @param mixed $default_values object or array of default values
+     * @param array $defaultvalues
      */
     public function set_data($defaultvalues) {
         if (is_object($defaultvalues)) {

--- a/classes/file_storage.php
+++ b/classes/file_storage.php
@@ -14,17 +14,15 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+namespace mod_questionnaire;
+
 /**
+ * Defines the file stoeage class for questionnaire.
  * @package mod_questionnaire
  * @copyright  2020 onwards Mike Churchward (mike.churchward@poetopensource.org)
  * @author Mike Churchward
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-
-namespace mod_questionnaire;
-
-defined('MOODLE_INTERNAL') || die();
-
 class file_storage extends \file_storage {
 
     /**

--- a/classes/generator/question_response.php
+++ b/classes/generator/question_response.php
@@ -14,20 +14,28 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+namespace mod_questionnaire\generator;
+
+use mod_questionnaire\responsetype\response\response;
+
 /**
  * Question response class
  * @author    gthomas2
+ * @copyright 2016 onward Mike Churchward (mike.churchward@poetopensource.org)
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @package mod_questionnaire
  */
-
-namespace mod_questionnaire\generator;
-
-defined('MOODLE_INTERNAL') || die();
-
 class question_response {
+    /** @var int $questionid */
     public $questionid;
+    /** @var response $response */
     public $response;
 
+    /**
+     * Class constructor.
+     * @param int $questionid
+     * @param response $response
+     */
     public function __construct($questionid, $response) {
         $this->questionid = $questionid;
         $this->response = $response;

--- a/classes/generator/question_response_rank.php
+++ b/classes/generator/question_response_rank.php
@@ -14,20 +14,28 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+namespace mod_questionnaire\generator;
+
+use mod_questionnaire\question\choice;
+
 /**
  * Question response rank class
  * @author    gthomas2
+ * @copyright 2016 onward Mike Churchward (mike.churchward@poetopensource.org)
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @package mod_questionnaire
  */
-
-namespace mod_questionnaire\generator;
-
-defined('MOODLE_INTERNAL') || die();
-
 class question_response_rank {
+    /** @var choice $choice */
     public $choice;
+    /** @var int $rankvalue */
     public $rankvalue;
 
+    /**
+     * Class constructor.
+     * @param choice $choice
+     * @param int $rank
+     */
     public function __construct($choice, $rank) {
         $this->choice = $choice;
         $this->rankvalue = $rank;

--- a/classes/output/completepage.php
+++ b/classes/output/completepage.php
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+namespace mod_questionnaire\output;
+
 /**
  * Contains class mod_questionnaire\output\viewpage
  *
@@ -22,11 +24,6 @@
  * @author     Mike Churchward
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-
-namespace mod_questionnaire\output;
-
-defined('MOODLE_INTERNAL') || die();
-
 class completepage implements \renderable, \templatable {
 
     /**
@@ -49,8 +46,8 @@ class completepage implements \renderable, \templatable {
 
     /**
      * Add data for export.
-     * @param string The index for the data.
-     * @param string The content for the index.
+     * @param string $element The index for the data.
+     * @param string $content The content for the index.
      */
     public function add_to_page($element, $content) {
         if ($element !== 'questions') {

--- a/classes/output/fbsectionspage.php
+++ b/classes/output/fbsectionspage.php
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+namespace mod_questionnaire\output;
+
 /**
  * Contains class mod_questionnaire\output\fbsectionspage
  *
@@ -22,11 +24,6 @@
  * @author     Mike Churchward
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-
-namespace mod_questionnaire\output;
-
-defined('MOODLE_INTERNAL') || die();
-
 class fbsectionspage implements \renderable, \templatable {
 
     /**
@@ -49,8 +46,8 @@ class fbsectionspage implements \renderable, \templatable {
 
     /**
      * Add data for export.
-     * @param string The index for the data.
-     * @param string The content for the index.
+     * @param string $element The index for the data.
+     * @param string $content The content for the index.
      */
     public function add_to_page($element, $content) {
         $this->data->{$element} = empty($this->data->{$element}) ? $content : ($this->data->{$element} . $content);

--- a/classes/output/feedbackpage.php
+++ b/classes/output/feedbackpage.php
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+namespace mod_questionnaire\output;
+
 /**
  * Contains class mod_questionnaire\output\feedback
  *
@@ -22,11 +24,6 @@
  * @author     Mike Churchward
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-
-namespace mod_questionnaire\output;
-
-defined('MOODLE_INTERNAL') || die();
-
 class feedbackpage implements \renderable, \templatable {
 
     /**
@@ -49,8 +46,8 @@ class feedbackpage implements \renderable, \templatable {
 
     /**
      * Add data for export.
-     * @param string The index for the data.
-     * @param string The content for the index.
+     * @param string $element The index for the data.
+     * @param string $content The content for the index.
      */
     public function add_to_page($element, $content) {
         $this->data->{$element} = empty($this->data->{$element}) ? $content : ($this->data->{$element} . $content);

--- a/classes/output/mobile.php
+++ b/classes/output/mobile.php
@@ -14,16 +14,18 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+namespace mod_questionnaire\output;
+
+use mod_questionnaire\responsetype\response\response;
+
 /**
  * Mobile output class for mod_questionnaire.
  *
- * @copyright 2018 Igor Sazonov <sovletig@gmail.com>
- * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @package    mod_questionnaire
+ * @copyright  2016 Mike Churchward (mike.churchward@poetgroup.org)
+ * @author     Mike Churchward
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-namespace mod_questionnaire\output;
-
-defined('MOODLE_INTERNAL') || die();
-
 class mobile {
 
     /**
@@ -202,8 +204,10 @@ class mobile {
     }
 
     /**
-     * @param $questionnaire
-     * @param $data
+     * Add the submissions.
+     * @param \questionnaire $questionnaire
+     * @param array $data
+     * @param int $userid
      */
     protected static function add_index_data($questionnaire, &$data, $userid) {
         // List any existing submissions, if user is allowed to review them.
@@ -226,9 +230,10 @@ class mobile {
     }
 
     /**
-     * @param $questionnaire
-     * @param $pagenum
-     * @param null $response
+     * Ass the questions for the page.
+     * @param \questionnaire $questionnaire
+     * @param int $pagenum
+     * @param response $response
      * @return array
      */
     protected static function add_pagequestion_data($questionnaire, $pagenum, $response=null) {

--- a/classes/output/mobile.php
+++ b/classes/output/mobile.php
@@ -48,7 +48,7 @@ class mobile {
         $completed = isset($args->completed) ? $args->completed : false;
 
         list($cm, $course, $questionnaire) = questionnaire_get_standard_page_items($cmid);
-        $questionnaire = new \questionnaire(0, $questionnaire, $course, $cm);
+        $questionnaire = new \questionnaire($course, $cm, 0, $questionnaire);
 
         $data = [];
         $data['cmid'] = $cmid;

--- a/classes/output/nonrespondentspage.php
+++ b/classes/output/nonrespondentspage.php
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+namespace mod_questionnaire\output;
+
 /**
  * Contains class mod_questionnaire\output\viewpage
  *
@@ -22,11 +24,6 @@
  * @author     Mike Churchward
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-
-namespace mod_questionnaire\output;
-
-defined('MOODLE_INTERNAL') || die();
-
 class nonrespondentspage implements \renderable, \templatable {
 
     /**
@@ -49,8 +46,8 @@ class nonrespondentspage implements \renderable, \templatable {
 
     /**
      * Add data for export.
-     * @param string The index for the data.
-     * @param string The content for the index.
+     * @param string $element The index for the data.
+     * @param string $content The content for the index.
      */
     public function add_to_page($element, $content) {
         $this->data->{$element} = empty($this->data->{$element}) ? $content : ($this->data->{$element} . $content);

--- a/classes/output/previewpage.php
+++ b/classes/output/previewpage.php
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+namespace mod_questionnaire\output;
+
 /**
  * Contains class mod_questionnaire\output\viewpage
  *
@@ -22,11 +24,6 @@
  * @author     Mike Churchward
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-
-namespace mod_questionnaire\output;
-
-defined('MOODLE_INTERNAL') || die();
-
 class previewpage implements \renderable, \templatable {
 
     /**
@@ -49,8 +46,8 @@ class previewpage implements \renderable, \templatable {
 
     /**
      * Add data for export.
-     * @param string The index for the data.
-     * @param string The content for the index.
+     * @param string $element The index for the data.
+     * @param string $content The content for the index.
      */
     public function add_to_page($element, $content) {
         if ($element === 'questions') {

--- a/classes/output/qsettingspage.php
+++ b/classes/output/qsettingspage.php
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+namespace mod_questionnaire\output;
+
 /**
  * Contains class mod_questionnaire\output\viewpage
  *
@@ -22,11 +24,6 @@
  * @author     Mike Churchward
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-
-namespace mod_questionnaire\output;
-
-defined('MOODLE_INTERNAL') || die();
-
 class qsettingspage implements \renderable, \templatable {
 
     /**
@@ -49,8 +46,8 @@ class qsettingspage implements \renderable, \templatable {
 
     /**
      * Add data for export.
-     * @param string The index for the data.
-     * @param string The content for the index.
+     * @param string $element The index for the data.
+     * @param string $content The content for the index.
      */
     public function add_to_page($element, $content) {
         $this->data->{$element} = empty($this->data->{$element}) ? $content : ($this->data->{$element} . $content);

--- a/classes/output/questionspage.php
+++ b/classes/output/questionspage.php
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+namespace mod_questionnaire\output;
+
 /**
  * Contains class mod_questionnaire\output\viewpage
  *
@@ -22,11 +24,6 @@
  * @author     Mike Churchward
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-
-namespace mod_questionnaire\output;
-
-defined('MOODLE_INTERNAL') || die();
-
 class questionspage implements \renderable, \templatable {
 
     /**
@@ -49,8 +46,8 @@ class questionspage implements \renderable, \templatable {
 
     /**
      * Add data for export.
-     * @param string The index for the data.
-     * @param string The content for the index.
+     * @param string $element The index for the data.
+     * @param string $content The content for the index.
      */
     public function add_to_page($element, $content) {
         $this->data->{$element} = empty($this->data->{$element}) ? $content : ($this->data->{$element} . $content);

--- a/classes/output/renderer.php
+++ b/classes/output/renderer.php
@@ -207,14 +207,14 @@ class renderer extends \plugin_renderer_base {
      * Render a question for a survey.
      * @param \mod_questionnaire\question\question $question The question object.
      * @param \mod_questionnaire\responsetype\response\response $response Any current response data.
-     * @param array $dependants Array of all questions/choices depending on $question.
      * @param int $qnum The question number.
      * @param boolean $blankquestionnaire Used for printing a blank one.
+     * @param array $dependants Array of all questions/choices depending on $question.
      * @return string The output for the page.
      */
-    public function question_output($question, $response, $dependants=[], $qnum, $blankquestionnaire) {
+    public function question_output($question, $response, $qnum, $blankquestionnaire, $dependants=[]) {
 
-        $pagetags = $question->question_output($response, $dependants, $qnum, $blankquestionnaire);
+        $pagetags = $question->question_output($response, $blankquestionnaire, $dependants, $qnum);
 
         // If the question has a template, then render it from the 'qformelement' context. If no template, then 'qformelement'
         // already contains HTML.

--- a/classes/output/renderer.php
+++ b/classes/output/renderer.php
@@ -14,6 +14,10 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+namespace mod_questionnaire\output;
+
+use mod_questionnaire\question\question;
+
 /**
  * Contains class mod_questionnaire\output\renderer
  *
@@ -22,11 +26,6 @@
  * @author     Mike Churchward
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-
-namespace mod_questionnaire\output;
-
-defined('MOODLE_INTERNAL') || die();
-
 class renderer extends \plugin_renderer_base {
     /**
      * Main view page.
@@ -167,7 +166,7 @@ class renderer extends \plugin_renderer_base {
 
     /**
      * Render the completion form control buttons.
-     * @param array | string $inputs Name/(Type/attribute) array of input types and values used by the form.
+     * @param array|string $inputs Name/(Type/attribute) array of input types and values used by the form.
      * @return string The output for the page.
      */
     public function complete_controlbuttons($inputs=null) {
@@ -182,6 +181,12 @@ class renderer extends \plugin_renderer_base {
         return $output;
     }
 
+    /**
+     * Calculate the progress and return it.
+     * @param int $section
+     * @param array $questionsbysec
+     * @return float
+     */
     private function calculate_progress($section, $questionsbysec) {
         $done = 0;
         $todo = 0;
@@ -196,6 +201,12 @@ class renderer extends \plugin_renderer_base {
         return round($done / ($done + $todo) * 100);
     }
 
+    /**
+     * Render the progress bar and return it.
+     * @param int $section
+     * @param array $questionsbysec
+     * @return bool|string
+     */
     public function render_progress_bar($section, $questionsbysec) {
         $templatecontext['percent'] = $this->calculate_progress($section, $questionsbysec);
         $helpicon = new \help_icon('progresshelp', 'mod_questionnaire');
@@ -268,10 +279,9 @@ class renderer extends \plugin_renderer_base {
 
     /**
      * Render all responses for a question.
-     * @param array \mod_questionnaire\responstype\response\response | string $responses
-     * @param array \mod_questionnaire\question\question $questions
+     * @param array|string $responses
+     * @param array $questions
      * @return string The output for the page.
-     * @throws \moodle_exception
      */
     public function all_response_output($responses, $questions = null) {
         $output = '';
@@ -302,13 +312,12 @@ class renderer extends \plugin_renderer_base {
 
     /**
      * Render a question results summary.
-     * @param mod_questionnaire\question\question $question The question object.
+     * @param question $question The question object.
      * @param array $rids The response ids.
      * @param string $sort The sort order being used.
      * @param string $anonymous The value of the anonymous setting.
      * @param bool $pdf
      * @return string The output for the page.
-     * @throws \moodle_exception
      */
     public function results_output($question, $rids, $sort, $anonymous, $pdf = false) {
         $pagetags = $question->display_results($rids, $sort, $anonymous);
@@ -392,9 +401,10 @@ class renderer extends \plugin_renderer_base {
 
 
     /**
-     * @param $children
-     * @param $langstring
-     * @param $strnum
+     * Generate and return any dependency warnings.
+     * @param array $children
+     * @param string $langstring
+     * @param int $strnum
      * @return string
      */
     public function dependency_warnings($children, $langstring, $strnum) {
@@ -454,8 +464,8 @@ class renderer extends \plugin_renderer_base {
 
     /**
      * Get displayable list of parents for the question in questions_form.
-     * @param $qid The question id.
-     * @param $dependencies Array of dependency records for a question.
+     * @param int $qid The question id.
+     * @param array $dependencies Array of dependency records for a question.
      * @return string
      */
     public function get_dependency_html($qid, $dependencies) {

--- a/classes/output/reportpage.php
+++ b/classes/output/reportpage.php
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+namespace mod_questionnaire\output;
+
 /**
  * Contains class mod_questionnaire\output\viewpage
  *
@@ -22,11 +24,6 @@
  * @author     Mike Churchward
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-
-namespace mod_questionnaire\output;
-
-defined('MOODLE_INTERNAL') || die();
-
 class reportpage implements \renderable, \templatable {
 
     /**
@@ -49,8 +46,8 @@ class reportpage implements \renderable, \templatable {
 
     /**
      * Add data for export.
-     * @param string The index for the data.
-     * @param string The content for the index.
+     * @param string $element The index for the data.
+     * @param string $content The content for the index.
      */
     public function add_to_page($element, $content) {
         if ($element === 'responses') {

--- a/classes/output/reportpagepdf.php
+++ b/classes/output/reportpagepdf.php
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+namespace mod_questionnaire\output;
+
 /**
  * Contains class mod_questionnaire\output\reportpagepdf
  *
@@ -22,11 +24,6 @@
  * @author     Mike Churchward
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-
-namespace mod_questionnaire\output;
-
-defined('MOODLE_INTERNAL') || die();
-
 class reportpagepdf implements \renderable, \templatable {
 
     /**
@@ -49,8 +46,8 @@ class reportpagepdf implements \renderable, \templatable {
 
     /**
      * Add data for export.
-     * @param string The index for the data.
-     * @param string The content for the index.
+     * @param string $element The index for the data.
+     * @param string $content The content for the index.
      */
     public function add_to_page($element, $content) {
         if ($element === 'responses') {

--- a/classes/output/responsepagepdf.php
+++ b/classes/output/responsepagepdf.php
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+namespace mod_questionnaire\output;
+
 /**
  * Contains class mod_questionnaire\output\responsepagepdf
  *
@@ -22,11 +24,6 @@
  * @author     Mike Churchward
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-
-namespace mod_questionnaire\output;
-
-defined('MOODLE_INTERNAL') || die();
-
 class responsepagepdf implements \renderable, \templatable {
 
     /**
@@ -49,8 +46,8 @@ class responsepagepdf implements \renderable, \templatable {
 
     /**
      * Add data for export.
-     * @param string The index for the data.
-     * @param string The content for the index.
+     * @param string $element The index for the data.
+     * @param string $content The content for the index.
      */
     public function add_to_page($element, $content) {
         if ($element === 'responses') {

--- a/classes/output/viewpage.php
+++ b/classes/output/viewpage.php
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+namespace mod_questionnaire\output;
+
 /**
  * Contains class mod_questionnaire\output\viewpage
  *
@@ -22,11 +24,6 @@
  * @author     Mike Churchward
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-
-namespace mod_questionnaire\output;
-
-defined('MOODLE_INTERNAL') || die();
-
 class viewpage implements \renderable, \templatable {
 
     /**
@@ -49,8 +46,8 @@ class viewpage implements \renderable, \templatable {
 
     /**
      * Add data for export.
-     * @param string The index for the data.
-     * @param string The content for the index.
+     * @param string $element The index for the data.
+     * @param string $content The content for the index.
      */
     public function add_to_page($element, $content) {
         $this->data->{$element} = empty($this->data->{$element}) ? $content : ($this->data->{$element} . $content);

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -211,7 +211,7 @@ class provider implements
                 $lastcmid = $response->cmid;
                 $course = $DB->get_record("course", ["id" => $response->qcourse]);
                 $cm = get_coursemodule_from_instance("questionnaire", $response->qid, $course->id);
-                $questionnaire = new \questionnaire($response->qid, null, $course, $cm);
+                $questionnaire = new \questionnaire($course, $cm, $response->qid, null);
             }
             $responsedata['responses'][] = [
                 'complete' => (($response->complete == 'y') ? get_string('yes') : get_string('no')),

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -14,6 +14,14 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+namespace mod_questionnaire\privacy;
+
+use \core_privacy\local\metadata\collection;
+use \core_privacy\local\request\contextlist;
+use \core_privacy\local\request\userlist;
+use \core_privacy\local\request\approved_contextlist;
+use \core_privacy\local\request\approved_userlist;
+
 /**
  * Contains class mod_questionnaire\privacy\provider
  *
@@ -22,17 +30,6 @@
  * @author     Mike Churchward
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-
-namespace mod_questionnaire\privacy;
-
-defined('MOODLE_INTERNAL') || die();
-
-use \core_privacy\local\metadata\collection;
-use \core_privacy\local\request\contextlist;
-use \core_privacy\local\request\userlist;
-use \core_privacy\local\request\approved_contextlist;
-use \core_privacy\local\request\approved_userlist;
-
 class provider implements
     // This plugin has data.
     \core_privacy\local\metadata\provider,
@@ -46,7 +43,7 @@ class provider implements
     /**
      * Returns meta data about this system.
      *
-     * @param   collection $items The collection to add metadata to.
+     * @param   collection $collection The collection to add metadata to.
      * @return  collection  The array of metadata
      */
     public static function get_metadata(collection $collection): collection {
@@ -323,7 +320,7 @@ class provider implements
     /**
      * Helper function to delete all the response records for a recordset array of responses.
      *
-     * @param   recordset $responses The list of response records to delete for.
+     * @param \moodle_recordset $responses The list of response records to delete for.
      */
     private static function delete_responses(\moodle_recordset $responses) {
         global $DB;

--- a/classes/question/check.php
+++ b/classes/question/check.php
@@ -14,24 +14,30 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+namespace mod_questionnaire\question;
+
 /**
  * This file contains the parent class for check question types.
  *
  * @author Mike Churchward
+ * @copyright  2016 onward Mike Churchward (mike.churchward@poetopensource.org)
  * @license http://www.gnu.org/copyleft/gpl.html GNU Public License
- * @package questiontypes
+ * @package mod_questionnaire
  */
-
-namespace mod_questionnaire\question;
-defined('MOODLE_INTERNAL') || die();
-use \html_writer;
-
 class check extends question {
 
+    /**
+     * Return the responseclass used.
+     * @return string
+     */
     protected function responseclass() {
         return '\\mod_questionnaire\\responsetype\\multiple';
     }
 
+    /**
+     * Return the help name.
+     * @return string
+     */
     public function helpname() {
         return 'checkboxes';
     }
@@ -45,7 +51,7 @@ class check extends question {
 
     /**
      * Override and return a form template if provided. Output of question_survey_display is iterpreted based on this.
-     * @return boolean | string
+     * @return string
      */
     public function question_template() {
         return 'mod_questionnaire/question_check';
@@ -53,7 +59,7 @@ class check extends question {
 
     /**
      * Override and return a form template if provided. Output of response_survey_display is iterpreted based on this.
-     * @return boolean | string
+     * @return string
      */
     public function response_template() {
         return 'mod_questionnaire/response_check';
@@ -72,7 +78,7 @@ class check extends question {
      * @param \mod_questionnaire\responsetype\response\response $response
      * @param array $dependants Array of all questions/choices depending on this question.
      * @param boolean $blankquestionnaire
-     * @return object The check question context tags.
+     * @return \stdClass The check question context tags.
      *
      */
     protected function question_survey_display($response, $dependants, $blankquestionnaire=false) {
@@ -153,7 +159,7 @@ class check extends question {
     /**
      * Return the context tags for the check response template.
      * @param \mod_questionnaire\responsetype\response\response $response
-     * @return object The check question response context tags.
+     * @return \stdClass The check question response context tags.
      */
     protected function response_survey_display($response) {
         static $uniquetag = 0;  // To make sure all radios have unique names.
@@ -194,7 +200,7 @@ class check extends question {
     /**
      * Check question's form data for valid response. Override this is type has specific format requirements.
      *
-     * @param object $responsedata The data entered into the response.
+     * @param \stdClass $responsedata The data entered into the response.
      * @return boolean
      */
     public function response_valid($responsedata) {
@@ -247,10 +253,20 @@ class check extends question {
         return $valid;
     }
 
+    /**
+     * Return the length form element.
+     * @param \MoodleQuickForm $mform
+     * @param string $helptext
+     */
     protected function form_length(\MoodleQuickForm $mform, $helptext = '') {
         return parent::form_length($mform, 'minforcedresponses');
     }
 
+    /**
+     * Return the precision form element.
+     * @param \MoodleQuickForm $mform
+     * @param string $helptext
+     */
     protected function form_precise(\MoodleQuickForm $mform, $helptext = '') {
         return parent::form_precise($mform, 'maxforcedresponses');
     }
@@ -266,6 +282,8 @@ class check extends question {
 
     /**
      * Preprocess choice data.
+     * @param \stdClass $formdata
+     * @return bool
      */
     protected function form_preprocess_choicedata($formdata) {
         if (empty($formdata->allchoices)) {
@@ -290,11 +308,10 @@ class check extends question {
     }
 
     /**
-     * @param $qnum
-     * @param $fieldkey
+     * Return the mobile question display.
+     * @param int $qnum
      * @param bool $autonum
      * @return \stdClass
-     * @throws \coding_exception
      */
     public function mobile_question_display($qnum, $autonum = false) {
         $mobiledata = parent::mobile_question_display($qnum, $autonum);
@@ -303,8 +320,8 @@ class check extends question {
     }
 
     /**
-     * @param $mobiledata
-     * @return mixed
+     * Return the mobile question choices display.
+     * @return array
      */
     public function mobile_question_choices_display() {
         $choices = parent::mobile_question_choices_display();
@@ -320,7 +337,8 @@ class check extends question {
     }
 
     /**
-     * @param $response
+     * Return the mobile response data.
+     * @param \stdClass $response
      * @return array
      */
     public function get_mobile_response_data($response) {

--- a/classes/question/choice.php
+++ b/classes/question/choice.php
@@ -14,18 +14,16 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+namespace mod_questionnaire\question;
+
 /**
  * This defines a structured class to hold question choices.
  *
  * @author Mike Churchward
  * @license http://www.gnu.org/copyleft/gpl.html GNU Public License
- * @package response
+ * @package mod_questionnaire
  * @copyright 2019, onwards Poet
  */
-
-namespace mod_questionnaire\question;
-defined('MOODLE_INTERNAL') || die();
-
 class choice {
 
     // Class properties.
@@ -47,10 +45,10 @@ class choice {
 
     /**
      * Choice constructor.
-     * @param null $id
-     * @param null $questionid
-     * @param null $content
-     * @param null $value
+     * @param int $id
+     * @param int $questionid
+     * @param string $content
+     * @param mixed $value
      */
     public function __construct($id = null, $questionid = null, $content = null, $value = null) {
         $this->id = $id;
@@ -80,7 +78,7 @@ class choice {
     /**
      * Create and return a choice object from data.
      *
-     * @param object | array $choicedata The data to load.
+     * @param \stdclass|array $choicedata The data to load.
      * @return choice
      */
     public static function create_from_data($choicedata) {
@@ -111,7 +109,9 @@ class choice {
     }
 
     /**
-     *
+     * Delete the choice record.
+     * @param int $id
+     * @return bool
      */
     public static function delete_from_db_by_id($id) {
         global $DB;
@@ -119,8 +119,8 @@ class choice {
     }
 
     /**
+     * Delete this record from the DB.
      * @return bool
-     * @throws \dml_exception
      */
     public function delete_from_db() {
         return self::delete_from_db_by_id($this->id);
@@ -148,9 +148,8 @@ class choice {
     /**
      * Return the string to display for an "other" option content string. If the option is not an "other", return false.
      *
-     * @param $content
-     * @return string | bool
-     * @throws \coding_exception
+     * @param string $content
+     * @return string|bool
      */
     public static function content_other_choice_display($content) {
         if (!self::content_is_other_choice($content)) {
@@ -164,7 +163,7 @@ class choice {
     /**
      * Return the string to display for an "other" option for this object. If the option is not an "other", return false.
      *
-     * @return string | bool
+     * @return string|bool
      */
     public function other_choice_display() {
         return self::content_other_choice_display($this->content);
@@ -172,7 +171,7 @@ class choice {
 
     /**
      * Is the content a named degree rate choice.
-     * @param $content
+     * @param string $content
      * @return array|bool
      */
     public static function content_is_named_degree_choice($content) {
@@ -203,8 +202,6 @@ class choice {
 
     /**
      * Return the string to use as an input name for an other choice.
-     *
-     * @param int $choiceid
      * @return string
      */
     public function other_choice_name() {

--- a/classes/question/date.php
+++ b/classes/question/date.php
@@ -14,24 +14,30 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+namespace mod_questionnaire\question;
+
 /**
  * This file contains the parent class for date question types.
  *
  * @author Mike Churchward
+ * @copyright  2016 onward Mike Churchward (mike.churchward@poetopensource.org)
  * @license http://www.gnu.org/copyleft/gpl.html GNU Public License
- * @package questiontypes
+ * @package mod_questionnaire
  */
-
-namespace mod_questionnaire\question;
-defined('MOODLE_INTERNAL') || die();
-use \html_writer;
-
 class date extends question {
 
+    /**
+     * Return the responseclass used.
+     * @return string
+     */
     protected function responseclass() {
         return '\\mod_questionnaire\\responsetype\\date';
     }
 
+    /**
+     * Return the help name.
+     * @return string
+     */
     public function helpname() {
         return 'date';
     }
@@ -55,10 +61,9 @@ class date extends question {
     /**
      * Return the context tags for the check question template.
      * @param \mod_questionnaire\responsetype\response\response $response
-     * @param $descendantsdata
+     * @param array $descendantsdata
      * @param boolean $blankquestionnaire
      * @return object The check question context tags.
-     * @throws \coding_exception
      */
     protected function question_survey_display($response, $descendantsdata, $blankquestionnaire=false) {
         // Date.
@@ -100,7 +105,7 @@ class date extends question {
     /**
      * Check question's form data for valid response. Override this is type has specific format requirements.
      *
-     * @param object $responsedata The data entered into the response.
+     * @param \stdClass $responsedata The data entered into the response.
      * @return boolean
      */
     public function response_valid($responsedata) {
@@ -125,17 +130,29 @@ class date extends question {
         }
     }
 
+    /**
+     * Return the form length.
+     * @param \MoodleQuickForm $mform
+     * @param string $helpname
+     * @return \MoodleQuickForm|void
+     */
     protected function form_length(\MoodleQuickForm $mform, $helpname = '') {
         return question::form_length_hidden($mform);
     }
 
+    /**
+     * Return the form precision.
+     * @param \MoodleQuickForm $mform
+     * @param string $helpname
+     * @return \MoodleQuickForm|void
+     */
     protected function form_precise(\MoodleQuickForm $mform, $helpname = '') {
         return question::form_precise_hidden($mform);
     }
 
     /**
      * Verify that the date provided is in the proper YYYY-MM-DD format.
-     * @param $date
+     * @param string $date
      * @return bool
      */
     public function check_date_format($date) {
@@ -187,11 +204,10 @@ class date extends question {
     }
 
     /**
-     * @param $qnum
-     * @param $fieldkey
+     * Does the question support mobile display.
+     * @param int $qnum
      * @param bool $autonum
      * @return \stdClass
-     * @throws \coding_exception
      */
     public function mobile_question_display($qnum, $autonum = false) {
         $mobiledata = parent::mobile_question_display($qnum, $autonum);
@@ -200,7 +216,7 @@ class date extends question {
     }
 
     /**
-     * @param $mobiledata
+     * Does the question have mobile choices.
      * @return mixed
      */
     public function mobile_question_choices_display() {

--- a/classes/question/drop.php
+++ b/classes/question/drop.php
@@ -14,25 +14,33 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+namespace mod_questionnaire\question;
+use \html_writer;
+use mod_questionnaire\question\choice;
+use mod_questionnaire\responsetype\response\response;
+
 /**
  * This file contains the parent class for drop question types.
  *
  * @author Mike Churchward
+ * @copyright 2016 onward Mike Churchward (mike.churchward@poetopensource.org)
  * @license http://www.gnu.org/copyleft/gpl.html GNU Public License
- * @package questiontypes
+ * @package mod_questionnaire
  */
-
-namespace mod_questionnaire\question;
-defined('MOODLE_INTERNAL') || die();
-use \html_writer;
-use mod_questionnaire\question\choice;
-
 class drop extends question {
 
+    /**
+     * Each question type must define its response class.
+     * @return string The response object based off of questionnaire_response_base.
+     */
     protected function responseclass() {
         return '\\mod_questionnaire\\responsetype\\single';
     }
 
+    /**
+     * Short name for this question type - no spaces, etc..
+     * @return string
+     */
     public function helpname() {
         return 'dropdown';
     }
@@ -46,7 +54,7 @@ class drop extends question {
 
     /**
      * Override and return a form template if provided. Output of question_survey_display is iterpreted based on this.
-     * @return boolean | string
+     * @return string
      */
     public function question_template() {
         return 'mod_questionnaire/question_drop';
@@ -54,7 +62,7 @@ class drop extends question {
 
     /**
      * Override and return a form template if provided. Output of response_survey_display is iterpreted based on this.
-     * @return boolean | string
+     * @return string
      */
     public function response_template() {
         return 'mod_questionnaire/response_drop';
@@ -62,7 +70,7 @@ class drop extends question {
 
     /**
      * Override this and return true if the question type allows dependent questions.
-     * @return boolean
+     * @return bool
      */
     public function allows_dependents() {
         return true;
@@ -70,6 +78,7 @@ class drop extends question {
 
     /**
      * True if question type supports feedback options. False by default.
+     * @return bool
      */
     public function supports_feedback() {
         return true;
@@ -115,8 +124,7 @@ class drop extends question {
     /**
      * Return the context tags for the drop response template.
      * @param \mod_questionnaire\responsetype\response\response $response
-     * @return object The check question response context tags.
-     * @throws \coding_exception
+     * @return \stdClass The check question response context tags.
      */
     protected function response_survey_display($response) {
         static $uniquetag = 0;  // To make sure all radios have unique names.
@@ -147,17 +155,26 @@ class drop extends question {
         return $resptags;
     }
 
+    /**
+     * Return the length form element.
+     * @param \MoodleQuickForm $mform
+     * @param string $helpname
+     */
     protected function form_length(\MoodleQuickForm $mform, $helpname = '') {
         return question::form_length_hidden($mform);
     }
 
+    /**
+     * Return the precision form element.
+     * @param \MoodleQuickForm $mform
+     * @param string $helpname
+     */
     protected function form_precise(\MoodleQuickForm $mform, $helpname = '') {
         return question::form_precise_hidden($mform);
     }
 
     /**
      * True if question provides mobile support.
-     *
      * @return bool
      */
     public function supports_mobile() {
@@ -165,11 +182,10 @@ class drop extends question {
     }
 
     /**
-     * @param $qnum
-     * @param $fieldkey
+     * Return the mobile question display.
+     * @param int $qnum
      * @param bool $autonum
      * @return \stdClass
-     * @throws \coding_exception
      */
     public function mobile_question_display($qnum, $autonum = false) {
         $mobiledata = parent::mobile_question_display($qnum, $autonum);
@@ -178,7 +194,8 @@ class drop extends question {
     }
 
     /**
-     * @param $response
+     * Return the mobile response data.
+     * @param response $response
      * @return array
      */
     public function get_mobile_response_data($response) {

--- a/classes/question/essay.php
+++ b/classes/question/essay.php
@@ -14,28 +14,30 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+namespace mod_questionnaire\question;
+use \html_writer;
+use mod_questionnaire\responsetype\response\response;
+
 /**
  * This file contains the parent class for essay question types.
  *
  * @author Mike Churchward
+ * @copyright 2016 onward Mike Churchward (mike.churchward@poetopensource.org)
  * @license http://www.gnu.org/copyleft/gpl.html GNU Public License
- * @package questiontypes
+ * @package mod_questionnaire
  */
-
-namespace mod_questionnaire\question;
-defined('MOODLE_INTERNAL') || die();
-use \html_writer;
-
 class essay extends text {
 
     /**
-     * @return object|string
+     * Each question type must define its response class.
+     * @return object The response object based off of questionnaire_response_base.
      */
     protected function responseclass() {
         return '\\mod_questionnaire\\responsetype\\text';
     }
 
     /**
+     * Short name for this question type - no spaces, etc..
      * @return string
      */
     public function helpname() {
@@ -59,10 +61,11 @@ class essay extends text {
     }
 
     /**
-     * @param \mod_questionnaire\responsetype\response\response $response
-     * @param $descendantsdata
+     * Question specific display method.
+     * @param response $response
+     * @param array $descendantsdata
      * @param bool $blankquestionnaire
-     * @return object|string
+     *
      */
     protected function question_survey_display($response, $descendantsdata, $blankquestionnaire=false) {
         $output = '';
@@ -102,8 +105,9 @@ class essay extends text {
     }
 
     /**
-     * @param \mod_questionnaire\responsetype\response\response $response
-     * @return object|string
+     * Question specific response display method.
+     * @param \stdClass $response
+     *
      */
     protected function response_survey_display($response) {
         if (isset($response->answers[$this->id])) {
@@ -120,11 +124,11 @@ class essay extends text {
     }
 
     // Note - intentianally returning 'precise' for length and 'length' for precise.
+
     /**
+     * Return the length form element.
      * @param \MoodleQuickForm $mform
      * @param string $helptext
-     * @return \MoodleQuickForm|void
-     * @throws \coding_exception
      */
     protected function form_length(\MoodleQuickForm $mform, $helptext = '') {
         $responseformats = array(
@@ -137,7 +141,6 @@ class essay extends text {
 
     /**
      * True if question provides mobile support.
-     *
      * @return bool
      */
     public function supports_mobile() {
@@ -145,10 +148,9 @@ class essay extends text {
     }
 
     /**
+     * Return the precision form element.
      * @param \MoodleQuickForm $mform
      * @param string $helptext
-     * @return \MoodleQuickForm|void
-     * @throws \coding_exception
      */
     protected function form_precise(\MoodleQuickForm $mform, $helptext = '') {
         $choices = array();

--- a/classes/question/numerical.php
+++ b/classes/question/numerical.php
@@ -14,39 +14,51 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+namespace mod_questionnaire\question;
+
 /**
  * This file contains the parent class for numeric question types.
  *
  * @author Mike Churchward
+ * @copyright  2016 onward Mike Churchward (mike.churchward@poetopensource.org)
  * @license http://www.gnu.org/copyleft/gpl.html GNU Public License
- * @package questiontypes
+ * @package mod_questionnaire
  */
-
-namespace mod_questionnaire\question;
-defined('MOODLE_INTERNAL') || die();
-
 class numerical extends question {
 
     /**
      * Constructor. Use to set any default properties.
-     *
+     * @param int $id
+     * @param \stdClass $question
+     * @param string $context
+     * @param array $params
      */
     public function __construct($id = 0, $question = null, $context = null, $params = []) {
         $this->length = 10;
         return parent::__construct($id, $question, $context, $params);
     }
 
+    /**
+     * Each question type must define its response class.
+     *
+     * @return string The response object based off of questionnaire_response_base.
+     *
+     */
     protected function responseclass() {
         return '\\mod_questionnaire\\responsetype\\numericaltext';
     }
 
+    /**
+     * Short name for this question type - no spaces, etc..
+     * @return string
+     */
     public function helpname() {
         return 'numeric';
     }
 
     /**
      * Override and return a form template if provided. Output of question_survey_display is iterpreted based on this.
-     * @return boolean | string
+     * @return string
      */
     public function question_template() {
         return 'mod_questionnaire/question_numeric';
@@ -54,7 +66,7 @@ class numerical extends question {
 
     /**
      * Override and return a response template if provided. Output of response_survey_display is iterpreted based on this.
-     * @return boolean | string
+     * @return string
      */
     public function response_template() {
         return 'mod_questionnaire/response_numeric';
@@ -63,10 +75,9 @@ class numerical extends question {
     /**
      * Return the context tags for the check question template.
      * @param \mod_questionnaire\responsetype\response\response $response
-     * @param $descendantsdata
+     * @param array $descendantsdata
      * @param boolean $blankquestionnaire
-     * @return object The check question context tags.
-     * @throws \coding_exception
+     * @return \stdClass The check question context tags.
      */
     protected function question_survey_display($response, $descendantsdata, $blankquestionnaire=false) {
         // Numeric.
@@ -119,7 +130,7 @@ class numerical extends question {
     /**
      * Check question's form data for valid response. Override this is type has specific format requirements.
      *
-     * @param object $responsedata The data entered into the response.
+     * @param \stdClass $responsedata The data entered into the response.
      * @return boolean
      */
     public function response_valid($responsedata) {
@@ -144,9 +155,8 @@ class numerical extends question {
 
     /**
      * Return the context tags for the numeric response template.
-     * @param object $data
-     * @return object The numeric question response context tags.
-     *
+     * @param \mod_questionnaire\responsetype\response\response $response
+     * @return \stdClass The numeric question response context tags.
      */
     protected function response_survey_display($response) {
         $resptags = new \stdClass();
@@ -157,18 +167,27 @@ class numerical extends question {
         return $resptags;
     }
 
+    /**
+     * Return the length form element.
+     * @param \MoodleQuickForm $mform
+     * @param string $helptext
+     */
     protected function form_length(\MoodleQuickForm $mform, $helptext = '') {
         $this->length = isset($this->length) ? $this->length : 10;
         return parent::form_length($mform, 'maxdigitsallowed');
     }
 
+    /**
+     * Return the precision form element.
+     * @param \MoodleQuickForm $mform
+     * @param string $helptext
+     */
     protected function form_precise(\MoodleQuickForm $mform, $helptext = '') {
         return parent::form_precise($mform, 'numberofdecimaldigits');
     }
 
     /**
      * True if question provides mobile support.
-     *
      * @return bool
      */
     public function supports_mobile() {
@@ -176,11 +195,10 @@ class numerical extends question {
     }
 
     /**
-     * @param $qnum
-     * @param $fieldkey
+     * Return the mobile question display.
+     * @param int $qnum
      * @param bool $autonum
      * @return \stdClass
-     * @throws \coding_exception
      */
     public function mobile_question_display($qnum, $autonum = false) {
         $mobiledata = parent::mobile_question_display($qnum, $autonum);
@@ -189,7 +207,8 @@ class numerical extends question {
     }
 
     /**
-     * @return mixed
+     * Return the mobile question choices display.
+     * @return array
      */
     public function mobile_question_choices_display() {
         $choices = [];

--- a/classes/question/pagebreak.php
+++ b/classes/question/pagebreak.php
@@ -14,29 +14,30 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+namespace mod_questionnaire\question;
+use mod_questionnaire\edit_question_form;
+use \questionnaire;
+
 /**
  * This file contains the parent class for pagebreak question types.
  *
  * @author Mike Churchward
+ * @copyright  2016 onward Mike Churchward (mike.churchward@poetopensource.org)
  * @license http://www.gnu.org/copyleft/gpl.html GNU Public License
- * @package questiontypes
+ * @package mod_questionnaire
  */
-
-namespace mod_questionnaire\question;
-use mod_questionnaire\edit_question_form;
-use \questionnaire;
-defined('MOODLE_INTERNAL') || die();
-
 class pagebreak extends question {
 
     /**
-     * @return object|string
+     * Each question type must define its response class.
+     * @return object The response object based off of questionnaire_response_base.
      */
     protected function responseclass() {
         return '';
     }
 
     /**
+     * Short name for this question type - no spaces, etc..
      * @return string
      */
     public function helpname() {
@@ -44,35 +45,40 @@ class pagebreak extends question {
     }
 
     /**
+     * Get the output for the start of the questions in a survey.
      * @param int $qnum
-     * @param null $response
-     * @return \stdClass|string
+     * @param \mod_questionnaire\responsetype\response\response $response
+     * @return \stdClass
      */
     public function questionstart_survey_display($qnum, $response=null) {
         return '';
     }
 
     /**
-     * @param object $data
-     * @param $descendantsdata
+     * Question specific display method.
+     * @param \stdClass $data
+     * @param array $descendantsdata
      * @param bool $blankquestionnaire
-     * @return string
+     *
      */
     protected function question_survey_display($data, $descendantsdata, $blankquestionnaire=false) {
         return '';
     }
 
     /**
-     * @param object $data
-     * @return string
+     * Question specific response display method.
+     * @param \stdClass $data
+     *
      */
     protected function response_survey_display($data) {
         return '';
     }
 
     /**
-     * @param edit_question_form $form
-     * @param questionnaire $questionnaire
+     * Override this, or any of the internal methods, to provide specific form data for editing the question type.
+     * The structure of the elements here is the default layout for the question form.
+     * @param edit_question_form $form The main moodleform object.
+     * @param questionnaire $questionnaire The questionnaire being edited.
      * @return bool
      */
     public function edit_form(edit_question_form $form, questionnaire $questionnaire) {
@@ -81,7 +87,6 @@ class pagebreak extends question {
 
     /**
      * True if question provides mobile support.
-     *
      * @return bool
      */
     public function supports_mobile() {
@@ -90,12 +95,9 @@ class pagebreak extends question {
 
     /**
      * Override and return false if not supporting mobile app.
-     *
-     * @param $qnum
-     * @param $fieldkey
+     * @param int $qnum
      * @param bool $autonum
      * @return \stdClass
-     * @throws \coding_exception
      */
     public function mobile_question_display($qnum, $autonum = false) {
         return false;

--- a/classes/question/question.php
+++ b/classes/question/question.php
@@ -846,12 +846,12 @@ abstract class question {
     /**
      * Get the output for question renderers / templates.
      * @param \mod_questionnaire\responsetype\response\response $response
+     * @param boolean $blankquestionnaire
      * @param array $dependants Array of all questions/choices depending on this question.
      * @param integer $qnum
-     * @param boolean $blankquestionnaire
      * @return \stdClass
      */
-    public function question_output($response, $dependants=[], $qnum='', $blankquestionnaire) {
+    public function question_output($response, $blankquestionnaire, $dependants=[], $qnum='') {
         $pagetags = $this->questionstart_survey_display($qnum, $response);
         $pagetags->qformelement = $this->question_survey_display($response, $dependants, $blankquestionnaire);
         return $pagetags;

--- a/classes/question/radio.php
+++ b/classes/question/radio.php
@@ -14,24 +14,30 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+namespace mod_questionnaire\question;
+
 /**
  * This file contains the parent class for radio question types.
  *
  * @author Mike Churchward
+ * @copyright 2016 onward Mike Churchward (mike.churchward@poetopensource.org)
  * @license http://www.gnu.org/copyleft/gpl.html GNU Public License
- * @package questiontypes
+ * @package mod_questionnaire
  */
-
-namespace mod_questionnaire\question;
-
-defined('MOODLE_INTERNAL') || die();
-
 class radio extends question {
 
+    /**
+     * Each question type must define its response class.
+     * @return object The response object based off of questionnaire_response_base.
+     */
     protected function responseclass() {
         return '\\mod_questionnaire\\responsetype\\single';
     }
 
+    /**
+     * Short name for this question type - no spaces, etc..
+     * @return string
+     */
     public function helpname() {
         return 'radiobuttons';
     }
@@ -228,6 +234,11 @@ class radio extends question {
         }
     }
 
+    /**
+     * Return the length form element.
+     * @param \MoodleQuickForm $mform
+     * @param string $helptext
+     */
     protected function form_length(\MoodleQuickForm $mform, $helptext = '') {
         $lengroup = [];
         $lengroup[] =& $mform->createElement('radio', 'length', '', get_string('vertical', 'questionnaire'), '0');
@@ -239,6 +250,11 @@ class radio extends question {
         return $mform;
     }
 
+    /**
+     * Return the precision form element.
+     * @param \MoodleQuickForm $mform
+     * @param string $helptext
+     */
     protected function form_precise(\MoodleQuickForm $mform, $helptext = '') {
         return question::form_precise_hidden($mform);
     }
@@ -253,11 +269,10 @@ class radio extends question {
     }
 
     /**
-     * @param $qnum
-     * @param $fieldkey
+     * Override and return false if not supporting mobile app.
+     * @param int $qnum
      * @param bool $autonum
      * @return \stdClass
-     * @throws \coding_exception
      */
     public function mobile_question_display($qnum, $autonum = false) {
         $mobiledata = parent::mobile_question_display($qnum, $autonum);
@@ -266,8 +281,8 @@ class radio extends question {
     }
 
     /**
-     * @param $mobiledata
-     * @return mixed
+     * Override and return false if not supporting mobile app.
+     * @return array
      */
     public function mobile_question_choices_display() {
         $choices = parent::mobile_question_choices_display();
@@ -281,7 +296,8 @@ class radio extends question {
     }
 
     /**
-     * @param $response
+     * Return the mobile response data.
+     * @param response $response
      * @return array
      */
     public function get_mobile_response_data($response) {

--- a/classes/question/rate.php
+++ b/classes/question/rate.php
@@ -14,25 +14,27 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+namespace mod_questionnaire\question;
+
 /**
  * This file contains the parent class for rate question types.
  *
  * @author Mike Churchward
+ * @copyright 2016 onward Mike Churchward (mike.churchward@poetopensource.org)
  * @license http://www.gnu.org/copyleft/gpl.html GNU Public License
- * @package questiontypes
+ * @package mod_questionnaire
  */
-
-namespace mod_questionnaire\question;
-defined('MOODLE_INTERNAL') || die();
-use \html_writer;
-
 class rate extends question {
 
+    /** @var array $nameddegrees */
     public $nameddegrees = [];
 
     /**
-     * Constructor. Use to set any default properties.
-     *
+     * The class constructor
+     * @param int $id
+     * @param \stdClass $question
+     * @param \context $context
+     * @param array $params
      */
     public function __construct($id = 0, $question = null, $context = null, $params = array()) {
         $this->length = 5;
@@ -40,10 +42,18 @@ class rate extends question {
         $this->add_nameddegrees_from_extradata();
     }
 
+    /**
+     * Each question type must define its response class.
+     * @return object The response object based off of questionnaire_response_base.
+     */
     protected function responseclass() {
         return '\\mod_questionnaire\\responsetype\\rank';
     }
 
+    /**
+     * Short name for this question type - no spaces, etc..
+     * @return string
+     */
     public function helpname() {
         return 'ratescale';
     }
@@ -73,7 +83,7 @@ class rate extends question {
 
     /**
      * Return true if rate scale type is set to "Normal".
-     * @param $scaletype
+     * @param int $scaletype
      * @return bool
      */
     public static function type_is_normal_rate_scale($scaletype) {
@@ -82,7 +92,7 @@ class rate extends question {
 
     /**
      * Return true if rate scale type is set to "N/A column".
-     * @param $scaletype
+     * @param int $scaletype
      * @return bool
      */
     public static function type_is_na_column($scaletype) {
@@ -91,7 +101,7 @@ class rate extends question {
 
     /**
      * Return true if rate scale type is set to "No duplicate choices".
-     * @param $scaletype
+     * @param int $scaletype
      * @return bool
      */
     public static function type_is_no_duplicate_choices($scaletype) {
@@ -100,7 +110,7 @@ class rate extends question {
 
     /**
      * Return true if rate scale type is set to "Osgood".
-     * @param $scaletype
+     * @param int $scaletype
      * @return bool
      */
     public static function type_is_osgood_rate_scale($scaletype) {
@@ -177,8 +187,8 @@ class rate extends question {
 
     /**
      * Return the context tags for the check question template.
-     * @param \mod_questionnaire\responsetype\response\response $data
-     * @param string $descendantdata
+     * @param \mod_questionnaire\responsetype\response\response $response
+     * @param string $descendantsdata
      * @param boolean $blankquestionnaire
      * @return object The check question context tags.
      *
@@ -399,7 +409,7 @@ class rate extends question {
     /**
      * Return the context tags for the rate response template.
      * @param \mod_questionnaire\responsetype\response\response $response
-     * @return object The rate question response context tags.
+     * @return \stdClass The rate question response context tags.
      * @throws \coding_exception
      */
     protected function response_survey_display($response) {
@@ -540,7 +550,7 @@ class rate extends question {
     /**
      * Check question's form data for complete response.
      *
-     * @param object $responsedata The data entered into the response.
+     * @param \stdClass $responsedata The data entered into the response.
      * @return boolean
      *
      */
@@ -592,7 +602,7 @@ class rate extends question {
     /**
      * Check question's form data for valid response. Override this is type has specific format requirements.
      *
-     * @param object $responsedata The data entered into the response.
+     * @param \stdClass $responsedata The data entered into the response.
      * @return boolean
      */
     public function response_valid($responsedata) {
@@ -653,10 +663,20 @@ class rate extends question {
         }
     }
 
+    /**
+     * Return the length form element.
+     * @param \MoodleQuickForm $mform
+     * @param string $helptext
+     */
     protected function form_length(\MoodleQuickForm $mform, $helptext = '') {
         return parent::form_length($mform, 'numberscaleitems');
     }
 
+    /**
+     * Return the precision form element.
+     * @param \MoodleQuickForm $mform
+     * @param string $helptext
+     */
     protected function form_precise(\MoodleQuickForm $mform, $helptext = '') {
         $precoptions = array("0" => get_string('normal', 'questionnaire'),
                              "1" => get_string('notapplicablecolumn', 'questionnaire'),
@@ -691,7 +711,8 @@ class rate extends question {
     }
 
     /**
-     * @param $formdata
+     * Any preprocessing of general data.
+     * @param \stdClass $formdata
      * @return bool
      */
     protected function form_preprocess_data($formdata) {
@@ -714,7 +735,9 @@ class rate extends question {
     }
 
     /**
-     * Preprocess choice data.
+     * Override this function for question specific choice preprocessing.
+     * @param \stdClass $formdata
+     * @return false
      */
     protected function form_preprocess_choicedata($formdata) {
         if (empty($formdata->allchoices)) {
@@ -757,9 +780,9 @@ class rate extends question {
     }
 
     /**
-     * @param $choicerecord
+     * Update the choice with the choicerecord.
+     * @param \stdClass $choicerecord
      * @return bool
-     * @throws \dml_exception
      */
     public function update_choice($choicerecord) {
         if ($nameddegree = \mod_questionnaire\question\choice::content_is_named_degree_choice($choicerecord->content)) {
@@ -771,9 +794,9 @@ class rate extends question {
     }
 
     /**
-     * @param $choicerecord
+     * Add a new choice to the database.
+     * @param \stdClass $choicerecord
      * @return bool
-     * @throws \dml_exception
      */
     public function add_choice($choicerecord) {
         if ($nameddegree = \mod_questionnaire\question\choice::content_is_named_degree_choice($choicerecord->content)) {
@@ -794,11 +817,10 @@ class rate extends question {
     }
 
     /**
-     * @param $qnum
-     * @param $fieldkey
+     * Override and return false if not supporting mobile app.
+     * @param int $qnum
      * @param bool $autonum
      * @return \stdClass
-     * @throws \coding_exception
      */
     public function mobile_question_display($qnum, $autonum = false) {
         $mobiledata = parent::mobile_question_display($qnum, $autonum);
@@ -812,8 +834,8 @@ class rate extends question {
     }
 
     /**
-     * @return mixed
-     * @throws \coding_exception
+     * Override and return false if not supporting mobile app.
+     * @return array
      */
     public function mobile_question_choices_display() {
         $choices = [];
@@ -908,8 +930,8 @@ class rate extends question {
     }
 
     /**
-     * @return mixed
-     * @throws \coding_exception
+     * Display the rates question for mobile.
+     * @return array
      */
     public function mobile_question_rates_display() {
         $rates = [];
@@ -926,7 +948,8 @@ class rate extends question {
     }
 
     /**
-     * @param $response
+     * Return the mobile response data.
+     * @param response $response
      * @return array
      */
     public function get_mobile_response_data($response) {
@@ -971,8 +994,7 @@ class rate extends question {
      * Helper function used to move existing named degree choices for the specified question from the "quest_choice" table to the
      * "question" table.
      * @param int $qid
-     * @param \stdClass | null $questionrec
-     * @throws \dml_exception
+     * @param null|\stdClass $questionrec
      */
     public static function move_nameddegree_choices(int $qid = 0, \stdClass $questionrec = null) {
         global $DB;
@@ -1023,6 +1045,7 @@ class rate extends question {
      * Helper function to move named degree choices for all questions, optionally for a specific surveyid.
      * This should only be called for an upgrade from before '2018110103', or from a restore operation for a version of a
      * questionnaire before '2018110103'.
+     * @param int|null $surveyid
      */
     public static function move_all_nameddegree_choices(int $surveyid = null) {
         global $DB;

--- a/classes/question/sectiontext.php
+++ b/classes/question/sectiontext.php
@@ -14,27 +14,28 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+namespace mod_questionnaire\question;
+
 /**
  * This file contains the parent class for sectiontext question types.
  *
  * @author Mike Churchward
+ * @copyright  2016 onward Mike Churchward (mike.churchward@poetopensource.org)
  * @license http://www.gnu.org/copyleft/gpl.html GNU Public License
- * @package questiontypes
+ * @package mod_questionnaire
  */
-
-namespace mod_questionnaire\question;
-defined('MOODLE_INTERNAL') || die();
-
 class sectiontext extends question {
 
     /**
-     * @return object|string
+     * Each question type must define its response class.
+     * @return object The response object based off of questionnaire_response_base.
      */
     protected function responseclass() {
         return '';
     }
 
     /**
+     * Short name for this question type - no spaces, etc..
      * @return string
      */
     public function helpname() {
@@ -81,7 +82,7 @@ class sectiontext extends question {
     /**
      * Return the context tags for the check question template.
      * @param \mod_questionnaire\responsetype\response\response $response
-     * @param array $dependants Array of all questions/choices depending on this question.
+     * @param array $descendantsdata Array of all questions/choices depending on this question.
      * @param boolean $blankquestionnaire
      * @return object The check question context tags.
      *
@@ -138,8 +139,9 @@ class sectiontext extends question {
     }
 
     /**
-     * @param object $data
-     * @return string
+     * Question specific response display method.
+     * @param \stdClass $data
+     *
      */
     protected function response_survey_display($data) {
         return '';
@@ -156,6 +158,7 @@ class sectiontext extends question {
     }
 
     /**
+     * Add the form required field.
      * @param \MoodleQuickForm $mform
      * @return \MoodleQuickForm
      */
@@ -164,18 +167,18 @@ class sectiontext extends question {
     }
 
     /**
+     * Return the length form element.
      * @param \MoodleQuickForm $mform
      * @param string $helpname
-     * @return \MoodleQuickForm|void
      */
     protected function form_length(\MoodleQuickForm $mform, $helpname = '') {
         return question::form_length_hidden($mform);
     }
 
     /**
+     * Return the precision form element.
      * @param \MoodleQuickForm $mform
      * @param string $helpname
-     * @return \MoodleQuickForm|void
      */
     protected function form_precise(\MoodleQuickForm $mform, $helpname = '') {
         return question::form_precise_hidden($mform);

--- a/classes/question/sectiontext.php
+++ b/classes/question/sectiontext.php
@@ -101,9 +101,10 @@ class sectiontext extends question {
 
         // In which section(s) is this question?
         foreach ($fbsections as $key => $fbsection) {
-            $scorecalculation = unserialize($fbsection->scorecalculation);
-            if (array_key_exists($this->id, $scorecalculation)) {
-                array_push($filteredsections, $fbsection->section);
+            if ($scorecalculation = unserialize($fbsection->scorecalculation)) {
+                if (array_key_exists($this->id, $scorecalculation)) {
+                    array_push($filteredsections, $fbsection->section);
+                }
             }
         }
 

--- a/classes/question/sectiontext.php
+++ b/classes/question/sectiontext.php
@@ -112,7 +112,7 @@ class sectiontext extends question {
         }
 
         list($cm, $course, $questionnaire) = questionnaire_get_standard_page_items(null, $response->questionnaireid);
-        $questionnaire = new \questionnaire(0, $questionnaire, $course, $cm);
+        $questionnaire = new \questionnaire($course, $cm, 0, $questionnaire);
         $questionnaire->add_renderer($PAGE->get_renderer('mod_questionnaire'));
         $questionnaire->add_page(new \mod_questionnaire\output\reportpage());
 

--- a/classes/question/text.php
+++ b/classes/question/text.php
@@ -14,22 +14,24 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+namespace mod_questionnaire\question;
+
 /**
  * This file contains the parent class for text question types.
  *
  * @author Mike Churchward
+ * @copyright 2016 onward Mike Churchward (mike.churchward@poetopensource.org)
  * @license http://www.gnu.org/copyleft/gpl.html GNU Public License
- * @package questiontypes
+ * @package mod_questionnaire
  */
-
-namespace mod_questionnaire\question;
-defined('MOODLE_INTERNAL') || die();
-
 class text extends question {
 
     /**
-     * Constructor. Use to set any default properties.
-     *
+     * The class constructor
+     * @param int $id
+     * @param \stdClass $question
+     * @param \context $context
+     * @param array $params
      */
     public function __construct($id = 0, $question = null, $context = null, $params = []) {
         $this->length = 20;
@@ -38,13 +40,15 @@ class text extends question {
     }
 
     /**
-     * @return object|string
+     * Each question type must define its response class.
+     * @return object The response object based off of questionnaire_response_base.
      */
     protected function responseclass() {
         return '\\mod_questionnaire\\responsetype\\text';
     }
 
     /**
+     * Short name for this question type - no spaces, etc..
      * @return string
      */
     public function helpname() {
@@ -68,11 +72,11 @@ class text extends question {
     }
 
     /**
-     * Return the context tags for the check question template.
-     * @param \mod_questionnaire\responsetype\response\response $response
-     * @param $descendantsdata
-     * @param boolean $blankquestionnaire
-     * @return object The check question context tags.
+     * Question specific display method.
+     * @param \stdClass $response
+     * @param array $descendantsdata
+     * @param bool $blankquestionnaire
+     *
      */
     protected function question_survey_display($response, $descendantsdata, $blankquestionnaire=false) {
         // Text Box.
@@ -93,9 +97,8 @@ class text extends question {
     }
 
     /**
-     * Return the context tags for the text response template.
-     * @param object $data
-     * @return object The radio question response context tags.
+     * Question specific response display method.
+     * @param \stdClass $response
      */
     protected function response_survey_display($response) {
         $resptags = new \stdClass();
@@ -107,6 +110,7 @@ class text extends question {
     }
 
     /**
+     * Return the length form element.
      * @param \MoodleQuickForm $mform
      * @param string $helptext
      */
@@ -115,6 +119,7 @@ class text extends question {
     }
 
     /**
+     * Return the precision form element.
      * @param \MoodleQuickForm $mform
      * @param string $helptext
      */
@@ -124,7 +129,6 @@ class text extends question {
 
     /**
      * True if question provides mobile support.
-     *
      * @return bool
      */
     public function supports_mobile() {
@@ -132,11 +136,10 @@ class text extends question {
     }
 
     /**
-     * @param $qnum
-     * @param $fieldkey
+     * Override and return false if not supporting mobile app.
+     * @param int $qnum
      * @param bool $autonum
      * @return \stdClass
-     * @throws \coding_exception
      */
     public function mobile_question_display($qnum, $autonum = false) {
         $mobiledata = parent::mobile_question_display($qnum, $autonum);
@@ -145,8 +148,8 @@ class text extends question {
     }
 
     /**
-     * @param $mobiledata
-     * @return mixed
+     * Override and return false if not supporting mobile app.
+     * @return array
      */
     public function mobile_question_choices_display() {
         $choices = [];

--- a/classes/question/yesno.php
+++ b/classes/question/yesno.php
@@ -14,30 +14,37 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+namespace mod_questionnaire\question;
+
 /**
  * This file contains the parent class for yesno question types.
  *
  * @author Mike Churchward
+ * @copyright  2016 onward Mike Churchward (mike.churchward@poetopensource.org)
  * @license http://www.gnu.org/copyleft/gpl.html GNU Public License
- * @package questiontypes
+ * @package mod_questionnaire
  */
-
-namespace mod_questionnaire\question;
-defined('MOODLE_INTERNAL') || die();
-
 class yesno extends question {
 
+    /**
+     * Each question type must define its response class.
+     * @return object The response object based off of questionnaire_response_base.
+     */
     protected function responseclass() {
         return '\\mod_questionnaire\\responsetype\\boolean';
     }
 
+    /**
+     * Short name for this question type - no spaces, etc..
+     * @return string
+     */
     public function helpname() {
         return 'yesno';
     }
 
     /**
      * Override and return a form template if provided. Output of question_survey_display is iterpreted based on this.
-     * @return boolean | string
+     * @return string
      */
     public function question_template() {
         return 'mod_questionnaire/question_yesno';
@@ -45,7 +52,7 @@ class yesno extends question {
 
     /**
      * Override and return a response template if provided. Output of question_survey_display is iterpreted based on this.
-     * @return boolean | string
+     * @return string
      */
     public function response_template() {
         return 'mod_questionnaire/response_yesno';
@@ -53,7 +60,7 @@ class yesno extends question {
 
     /**
      * Override this and return true if the question type allows dependent questions.
-     * @return boolean
+     * @return bool
      */
     public function allows_dependents() {
         return true;
@@ -61,6 +68,7 @@ class yesno extends question {
 
     /**
      * True if question type supports feedback options. False by default.
+     * @return bool
      */
     public function supports_feedback() {
         return true;
@@ -68,6 +76,7 @@ class yesno extends question {
 
     /**
      * True if the question supports feedback and has valid settings for feedback. Override if the default logic is not enough.
+     * @return bool
      */
     public function valid_feedback() {
         return $this->required();
@@ -196,10 +205,20 @@ class yesno extends question {
         return $resptags;
     }
 
+    /**
+     * Return the length form element.
+     * @param \MoodleQuickForm $mform
+     * @param string $helpname
+     */
     protected function form_length(\MoodleQuickForm $mform, $helpname = '') {
         return question::form_length_hidden($mform);
     }
 
+    /**
+     * Return the precision form element.
+     * @param \MoodleQuickForm $mform
+     * @param string $helpname
+     */
     protected function form_precise(\MoodleQuickForm $mform, $helpname = '') {
         return question::form_precise_hidden($mform);
     }
@@ -214,11 +233,10 @@ class yesno extends question {
     }
 
     /**
-     * @param $qnum
-     * @param $fieldkey
+     * Override and return false if not supporting mobile app.
+     * @param int $qnum
      * @param bool $autonum
      * @return \stdClass
-     * @throws \coding_exception
      */
     public function mobile_question_display($qnum, $autonum = false) {
         $mobiledata = parent::mobile_question_display($qnum, $autonum);
@@ -227,8 +245,8 @@ class yesno extends question {
     }
 
     /**
-     * @return mixed
-     * @throws \coding_exception
+     * Override and return false if not supporting mobile app.
+     * @return array
      */
     public function mobile_question_choices_display() {
         $choices = [];
@@ -255,7 +273,8 @@ class yesno extends question {
     }
 
     /**
-     * @param $response
+     * Return the mobile response data.
+     * @param response $response
      * @return array
      */
     public function get_mobile_response_data($response) {

--- a/classes/questions_form.php
+++ b/classes/questions_form.php
@@ -14,26 +14,35 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * @package mod_questionnaire
- * @copyright  2016 Mike Churchward (mike.churchward@poetgroup.org)
- * @author Mike Churchward & Joseph Rézeau
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
 namespace mod_questionnaire;
 
 defined('MOODLE_INTERNAL') || die();
 
 require_once($CFG->libdir . '/formslib.php');
 
+/**
+ * The form definition class for questions.
+ *
+ * @package mod_questionnaire
+ * @copyright  2016 Mike Churchward (mike.churchward@poetgroup.org)
+ * @author Mike Churchward & Joseph Rézeau
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
 class questions_form extends \moodleform {
 
+    /**
+     * The constructor.
+     * @param mixed $action
+     * @param bool $moveq
+     */
     public function __construct($action, $moveq=false) {
         $this->moveq = $moveq;
         return parent::__construct($action);
     }
 
+    /**
+     * Form definition.
+     */
     public function definition() {
         global $CFG, $questionnaire, $SESSION;
         global $DB;
@@ -367,9 +376,14 @@ class questions_form extends \moodleform {
         $mform->addElement('html', '</div>');
     }
 
+    /**
+     * Form validation.
+     * @param array $data
+     * @param array $files
+     * @return array
+     */
     public function validation($data, $files) {
         $errors = parent::validation($data, $files);
         return $errors;
     }
-
 }

--- a/classes/responsetype/answer/answer.php
+++ b/classes/responsetype/answer/answer.php
@@ -14,18 +14,16 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+namespace mod_questionnaire\responsetype\answer;
+
 /**
  * This defines a structured class to hold question answers.
  *
  * @author Mike Churchward
  * @license http://www.gnu.org/copyleft/gpl.html GNU Public License
- * @package response
+ * @package mod_questionnaire
  * @copyright 2019, onwards Poet
  */
-
-namespace mod_questionnaire\responsetype\answer;
-defined('MOODLE_INTERNAL') || die();
-
 class answer {
 
     // Class properties.
@@ -64,7 +62,7 @@ class answer {
     /**
      * Create and return an answer object from data.
      *
-     * @param \stdClass | array $answerdata The data to load.
+     * @param \stdClass|array $answerdata The data to load.
      * @return answer
      */
     public static function create_from_data($answerdata) {

--- a/classes/responsetype/boolean.php
+++ b/classes/responsetype/boolean.php
@@ -14,16 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * This file contains the parent class for questionnaire question types.
- *
- * @author Mike Churchward
- * @license http://www.gnu.org/copyleft/gpl.html GNU Public License
- * @package questiontypes
- */
-
 namespace mod_questionnaire\responsetype;
-defined('MOODLE_INTERNAL') || die();
 
 use coding_exception;
 use dml_exception;
@@ -34,13 +25,17 @@ use stdClass;
  * Class for boolean response types.
  *
  * @author Mike Churchward
- * @package response
+ * @copyright 2016 onward Mike Churchward (mike.churchward@poetopensource.org)
+ * @license http://www.gnu.org/copyleft/gpl.html GNU Public License
+ * @package mod_questionnaire
  */
-
 class boolean extends responsetype {
 
     /**
-     * @return string
+     * Provide the necessary response data table name. Should probably always be used with late static binding 'static::' form
+     * rather than 'self::' form to allow for class extending.
+     *
+     * @return string response table name.
      */
     public static function response_table() {
         return 'questionnaire_response_bool';
@@ -81,10 +76,10 @@ class boolean extends responsetype {
     }
 
     /**
-     * @param \mod_questionnaire\responsetype\response\response|\stdClass $responsedata
-     * @return bool|int
-     * @throws \coding_exception
-     * @throws \dml_exception
+     * Insert a provided response to the question.
+     *
+     * @param object $responsedata All of the responsedata as an object.
+     * @return int|bool - on error the subtype should call set_error and return false.
      */
     public function insert_response($responsedata) {
         global $DB;
@@ -107,11 +102,11 @@ class boolean extends responsetype {
     }
 
     /**
-     * @param bool $rids
-     * @param bool $anonymous
-     * @return array
-     * @throws coding_exception
-     * @throws dml_exception
+     * Provide the result information for the specified result records.
+     *
+     * @param int|array $rids - A single response id, or array.
+     * @param boolean $anonymous - Whether or not responses are anonymous.
+     * @return array - Array of data records.
      */
     public function get_results($rids=false, $anonymous=false) {
         global $DB;
@@ -134,8 +129,8 @@ class boolean extends responsetype {
 
     /**
      * If the choice id needs to be transformed into a different value, override this in the child class.
-     * @param $choiceid
-     * @return mixed
+     * @param int $choiceid
+     * @return string
      */
     public function transform_choiceid($choiceid) {
         if ($choiceid == 0) {

--- a/classes/responsetype/date.php
+++ b/classes/responsetype/date.php
@@ -14,16 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * This file contains the parent class for questionnaire question types.
- *
- * @author Mike Churchward
- * @license http://www.gnu.org/copyleft/gpl.html GNU Public License
- * @package questiontypes
- */
-
 namespace mod_questionnaire\responsetype;
-defined('MOODLE_INTERNAL') || die();
 
 use mod_questionnaire\db\bulk_sql_config;
 
@@ -31,12 +22,16 @@ use mod_questionnaire\db\bulk_sql_config;
  * Class for date response types.
  *
  * @author Mike Churchward
- * @package responsetypes
+ * @copyright 2016 onward Mike Churchward (mike.churchward@poetopensource.org)
+ * @license http://www.gnu.org/copyleft/gpl.html GNU Public License
+ * @package mod_questionnaire
  */
-
 class date extends responsetype {
     /**
-     * @return string
+     * Provide the necessary response data table name. Should probably always be used with late static binding 'static::' form
+     * rather than 'self::' form to allow for class extending.
+     *
+     * @return string response table name.
      */
     public static function response_table() {
         return 'questionnaire_response_date';
@@ -77,10 +72,10 @@ class date extends responsetype {
     }
 
     /**
-     * @param \mod_questionnaire\responsetype\response\response\ $responsedata
-     * @return bool|int
-     * @throws \coding_exception
-     * @throws \dml_exception
+     * Insert a provided response to the question.
+     *
+     * @param object $responsedata All of the responsedata as an object.
+     * @return int|bool - on error the subtype should call set_error and return false.
      */
     public function insert_response($responsedata) {
         global $DB;
@@ -108,11 +103,11 @@ class date extends responsetype {
     }
 
     /**
-     * @param bool $rids
-     * @param bool $anonymous
-     * @return array
-     * @throws \coding_exception
-     * @throws \dml_exception
+     * Provide the result information for the specified result records.
+     *
+     * @param int|array $rids - A single response id, or array.
+     * @param boolean $anonymous - Whether or not responses are anonymous.
+     * @return array - Array of data records.
      */
     public function get_results($rids=false, $anonymous=false) {
         global $DB;
@@ -146,11 +141,12 @@ class date extends responsetype {
     }
 
     /**
-     * @param bool $rids
-     * @param string $sort
-     * @param bool $anonymous
-     * @return string
-     * @throws \coding_exception
+     * Provide the result information for the specified result records.
+     *
+     * @param int|array $rids - A single response id, or array.
+     * @param string $sort - Optional display sort.
+     * @param boolean $anonymous - Whether or not responses are anonymous.
+     * @return string - Display output.
      */
     public function display_results($rids=false, $sort='', $anonymous=false) {
         $numresps = count($rids);
@@ -174,15 +170,14 @@ class date extends responsetype {
     }
 
     /**
-     * Override the results tags function for templates for questions with dates.
+     * Gets the results tags for templates for questions with defined choices (single, multiple, boolean).
      *
-     * @param $weights
-     * @param $participants Number of questionnaire participants.
-     * @param $respondents Number of question respondents.
-     * @param $showtotals
+     * @param arrays $weights
+     * @param int $participants Number of questionnaire participants.
+     * @param int $respondents Number of question respondents.
+     * @param int $showtotals
      * @param string $sort
      * @return \stdClass
-     * @throws \coding_exception
      */
     public function get_results_tags($weights, $participants, $respondents, $showtotals = 1, $sort = '') {
         $dateformat = get_string('strfdate', 'questionnaire');

--- a/classes/responsetype/multiple.php
+++ b/classes/responsetype/multiple.php
@@ -14,26 +14,16 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * This file contains the parent class for questionnaire question types.
- *
- * @author Mike Churchward
- * @license http://www.gnu.org/copyleft/gpl.html GNU Public License
- * @package questiontypes
- */
-
 namespace mod_questionnaire\responsetype;
-defined('MOODLE_INTERNAL') || die();
-
-use mod_questionnaire\db\bulk_sql_config;
 
 /**
  * Class for multiple response types.
  *
  * @author Mike Churchward
- * @package responsetypes
+ * @copyright 2016 onward Mike Churchward (mike.churchward@poetopensource.org)
+ * @license http://www.gnu.org/copyleft/gpl.html GNU Public License
+ * @package mod_questionnaire
  */
-
 class multiple extends single {
     /**
      * The only differences between multuple and single responses are the
@@ -156,11 +146,13 @@ class multiple extends single {
 
     /**
      * Return sql and params for getting responses in bulk.
-     * @author Guy Thomas
      * @param int|array $questionnaireids One id, or an array of ids.
      * @param bool|int $responseid
      * @param bool|int $userid
+     * @param bool $groupid
+     * @param int $showincompletes
      * @return array
+     * author Guy Thomas
      */
     public function get_bulk_sql($questionnaireids, $responseid = false, $userid = false, $groupid = false, $showincompletes = 0) {
         global $DB;
@@ -208,8 +200,8 @@ class multiple extends single {
 
     /**
      * Return sql for getting responses in bulk.
-     * @author Guy Thomas
      * @return string
+     * author Guy Thomas
      */
     protected function bulk_sql() {
         global $DB;

--- a/classes/responsetype/numericaltext.php
+++ b/classes/responsetype/numericaltext.php
@@ -14,26 +14,16 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * This file contains the numerical text response type class.
- *
- * @author Mike Churchward
- * @license http://www.gnu.org/copyleft/gpl.html GNU Public License
- * @package responstype
- */
-
 namespace mod_questionnaire\responsetype;
-defined('MOODLE_INTERNAL') || die();
-
-use mod_questionnaire\db\bulk_sql_config;
 
 /**
  * Class for numerical text response types.
  *
  * @author Mike Churchward
- * @package responsetypes
+ * @copyright 2016 onward Mike Churchward (mike.churchward@poetopensource.org)
+ * @license http://www.gnu.org/copyleft/gpl.html GNU Public License
+ * @package mod_questionnaire
  */
-
 class numericaltext extends text {
     /**
      * Provide an array of answer objects from web form data for the question.
@@ -59,11 +49,12 @@ class numericaltext extends text {
     }
 
     /**
-     * @param bool $rids
-     * @param string $sort
-     * @param bool $anonymous
-     * @return string
-     * @throws \coding_exception
+     * Provide the result information for the specified result records.
+     *
+     * @param int|array $rids - A single response id, or array.
+     * @param string $sort - Optional display sort.
+     * @param boolean $anonymous - Whether or not responses are anonymous.
+     * @return string - Display output.
      */
     public function display_results($rids=false, $sort='', $anonymous=false) {
         if (is_array($rids)) {

--- a/classes/responsetype/rank.php
+++ b/classes/responsetype/rank.php
@@ -14,16 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * This file contains the parent class for questionnaire question types.
- *
- * @author Mike Churchward
- * @license http://www.gnu.org/copyleft/gpl.html GNU Public License
- * @package questiontypes
- */
-
 namespace mod_questionnaire\responsetype;
-defined('MOODLE_INTERNAL') || die();
 
 use Composer\Package\Package;
 use mod_questionnaire\db\bulk_sql_config;
@@ -32,12 +23,16 @@ use mod_questionnaire\db\bulk_sql_config;
  * Class for rank responses.
  *
  * @author Mike Churchward
- * @package responsetypes
+ * @copyright 2016 onward Mike Churchward (mike.churchward@poetopensource.org)
+ * @license http://www.gnu.org/copyleft/gpl.html GNU Public License
+ * @package mod_questionnaire
  */
-
 class rank extends responsetype {
     /**
-     * @return string
+     * Provide the necessary response data table name. Should probably always be used with late static binding 'static::' form
+     * rather than 'self::' form to allow for class extending.
+     *
+     * @return string response table name.
      */
     public static function response_table() {
         return 'questionnaire_response_rank';
@@ -107,10 +102,10 @@ class rank extends responsetype {
     }
 
     /**
-     * @param \mod_questionnaire\responsetype\response\response|\stdClass $responsedata
-     * @return bool|int
-     * @throws \coding_exception
-     * @throws \dml_exception
+     * Insert a provided response to the question.
+     *
+     * @param object $responsedata All of the responsedata as an object.
+     * @return int|bool - on error the subtype should call set_error and return false.
      */
     public function insert_response($responsedata) {
         global $DB;
@@ -289,10 +284,12 @@ class rank extends responsetype {
     }
 
     /**
-     * @param bool $rids
-     * @param string $sort
-     * @param bool $anonymous
-     * @return string
+     * Provide the result information for the specified result records.
+     *
+     * @param int|array $rids - A single response id, or array.
+     * @param string $sort - Optional display sort.
+     * @param boolean $anonymous - Whether or not responses are anonymous.
+     * @return string - Display output.
      */
     public function display_results($rids=false, $sort='', $anonymous=false) {
         $output = '';
@@ -435,10 +432,10 @@ class rank extends responsetype {
     }
 
     /**
-     * @param $sort
+     * Return a structure for averages.
+     * @param string $sort
      * @param string $stravgvalue
      * @return \stdClass
-     * @throws \coding_exception
      */
     private function mkresavg($sort, $stravgvalue='') {
         global $CFG;
@@ -739,12 +736,11 @@ class rank extends responsetype {
     }
 
     /**
-     * @param $rids
-     * @param $rows
-     * @param $sort
+     * Return a structure for counts.
+     * @param array $rids
+     * @param array $rows
+     * @param string $sort
      * @return \stdClass
-     * @throws \coding_exception
-     * @throws \dml_exception
      */
     private function mkrescount($rids, $rows, $sort) {
         // Display number of responses to Rate questions - see http://moodle.org/mod/forum/discuss.php?d=185106.
@@ -947,9 +943,9 @@ class rank extends responsetype {
     }
 
     /**
-     * Sorting functions for ascending and descending.
-     * @param $a
-     * @param $b
+     * Sorting function for ascending.
+     * @param \stdClass $a
+     * @param \stdClass $b
      * @return int
      */
     private static function sortavgasc($a, $b) {
@@ -965,8 +961,9 @@ class rank extends responsetype {
     }
 
     /**
-     * @param $a
-     * @param $b
+     * Sorting function for descending.
+     * @param \stdClass $a
+     * @param \stdClass $b
      * @return int
      */
     private static function sortavgdesc($a, $b) {

--- a/classes/responsetype/response/response.php
+++ b/classes/responsetype/response/response.php
@@ -14,20 +14,16 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+namespace mod_questionnaire\responsetype\response;
+
 /**
  * This defines a structured class to hold responses.
  *
  * @author Mike Churchward
  * @license http://www.gnu.org/copyleft/gpl.html GNU Public License
- * @package response
+ * @package mod_questionnaire
  * @copyright 2019, onwards Poet
  */
-
-namespace mod_questionnaire\responsetype\response;
-use mod_questionnaire\responsetype\answer\answer;
-
-defined('MOODLE_INTERNAL') || die();
-
 class response {
 
     // Class properties.
@@ -81,7 +77,7 @@ class response {
     /**
      * Create and return a response object from data.
      *
-     * @param object | array $responsedata The data to load.
+     * @param \stdClass|array $responsedata The data to load.
      * @return response
      */
     public static function create_from_data($responsedata) {
@@ -104,9 +100,8 @@ class response {
      * Provide a response object from web form data to the question.
      *
      * @param \stdClass $responsedata All of the responsedata as an object.
-     * @param array \mod_questionnaire\question\question $questions
+     * @param array $questions
      * @return bool|response A response object.
-     * @throws \coding_exception
      */
     public static function response_from_webform($responsedata, $questions) {
         global $USER;
@@ -125,10 +120,10 @@ class response {
     /**
      * Provide a response object from mobile app data to the question.
      *
-     * @param $questionnaireid
-     * @param $responseid
+     * @param id $questionnaireid
+     * @param id $responseid
      * @param \stdClass $responsedata All of the responsedata as an object.
-     * @param $questions Array of question objects.
+     * @param array $questions Array of question objects.
      * @return bool|response A response object.
      */
     public static function response_from_appdata($questionnaireid, $responseid, $responsedata, $questions) {

--- a/classes/responsetype/responsetype.php
+++ b/classes/responsetype/responsetype.php
@@ -14,28 +14,21 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * This file contains the parent class for questionnaire response types.
- *
- * @author Mike Churchward
- * @license http://www.gnu.org/copyleft/gpl.html GNU Public License
- * @package response
- */
-
 namespace mod_questionnaire\responsetype;
-defined('MOODLE_INTERNAL') || die();
+
 use \html_writer;
 use \html_table;
 
 use mod_questionnaire\db\bulk_sql_config;
 
 /**
- * Class for describing a response.
+ * This file contains the parent class for questionnaire response types.
  *
  * @author Mike Churchward
- * @package response
+ * @copyright 2016 onward Mike Churchward (mike.churchward@poetopensource.org)
+ * @license http://www.gnu.org/copyleft/gpl.html GNU Public License
+ * @package mod_questionnaire
  */
-
 abstract class responsetype {
 
     // Class properties.
@@ -118,7 +111,7 @@ abstract class responsetype {
 
     /**
      * If the choice id needs to be transformed into a different value, override this in the child class.
-     * @param $choiceid
+     * @param mixed $choiceid
      * @return mixed
      */
     public function transform_choiceid($choiceid) {
@@ -137,13 +130,12 @@ abstract class responsetype {
     /**
      * Gets the results tags for templates for questions with defined choices (single, multiple, boolean).
      *
-     * @param $weights
-     * @param $participants Number of questionnaire participants.
-     * @param $respondents Number of question respondents.
-     * @param $showtotals
+     * @param array $weights
+     * @param int $participants Number of questionnaire participants.
+     * @param int $respondents Number of question respondents.
+     * @param int $showtotals
      * @param string $sort
      * @return \stdClass
-     * @throws \coding_exception
      */
     public function get_results_tags($weights, $participants, $respondents, $showtotals = 1, $sort = '') {
         global $CFG;
@@ -285,8 +277,8 @@ abstract class responsetype {
     /**
      * Return all the fields to be used for users in bulk questionnaire sql.
      *
-     * @author: Guy Thomas
      * @return string
+     * author: Guy Thomas
      */
     protected function user_fields_sql() {
         if (class_exists('\core_user\fields')) {
@@ -306,12 +298,13 @@ abstract class responsetype {
 
     /**
      * Return sql and params for getting responses in bulk.
-     * @author Guy Thomas
      * @param int|array $questionnaireids One id, or an array of ids.
      * @param bool|int $responseid
      * @param bool|int $userid
      * @param bool|int $groupid
+     * @param int $showincompletes
      * @return array
+     * author Guy Thomas
      */
     public function get_bulk_sql($questionnaireids, $responseid = false, $userid = false, $groupid = false, $showincompletes = 0) {
         global $DB;

--- a/classes/responsetype/single.php
+++ b/classes/responsetype/single.php
@@ -14,28 +14,22 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * This file contains the parent class for questionnaire question types.
- *
- * @author Mike Churchward
- * @license http://www.gnu.org/copyleft/gpl.html GNU Public License
- * @package questiontypes
- */
-
 namespace mod_questionnaire\responsetype;
-
-defined('MOODLE_INTERNAL') || die();
 
 /**
  * Class for single response types.
  *
  * @author Mike Churchward
- * @package responsetypes
+ * @copyright 2016 onward Mike Churchward (mike.churchward@poetopensource.org)
+ * @license http://www.gnu.org/copyleft/gpl.html GNU Public License
+ * @package mod_questionnaire
  */
-
 class single extends responsetype {
     /**
-     * @return string
+     * Provide the necessary response data table name. Should probably always be used with late static binding 'static::' form
+     * rather than 'self::' form to allow for class extending.
+     *
+     * @return string response table name.
      */
     public static function response_table() {
         return 'questionnaire_resp_single';
@@ -96,10 +90,10 @@ class single extends responsetype {
     }
 
     /**
-     * @param \mod_questionnaire\responsetype\response\response|\stdClass $responsedata
-     * @return bool|int
-     * @throws \coding_exception
-     * @throws \dml_exception
+     * Insert a provided response to the question.
+     *
+     * @param object $responsedata All of the responsedata as an object.
+     * @return int|bool - on error the subtype should call set_error and return false.
      */
     public function insert_response($responsedata) {
         global $DB;
@@ -139,11 +133,11 @@ class single extends responsetype {
     }
 
     /**
-     * @param bool $rids
-     * @param bool $anonymous
-     * @return array
-     * @throws \coding_exception
-     * @throws \dml_exception
+     * Provide the result information for the specified result records.
+     *
+     * @param int|array $rids - A single response id, or array.
+     * @param boolean $anonymous - Whether or not responses are anonymous.
+     * @return array - Array of data records.
      */
     public function get_results($rids=false, $anonymous=false) {
         global $DB;
@@ -331,11 +325,13 @@ class single extends responsetype {
 
     /**
      * Return sql and params for getting responses in bulk.
-     * @author Guy Thomas
      * @param int|array $questionnaireids One id, or an array of ids.
      * @param bool|int $responseid
      * @param bool|int $userid
+     * @param bool|int $groupid
+     * @param int $showincompletes
      * @return array
+     * author Guy Thomas
      */
     public function get_bulk_sql($questionnaireids, $responseid = false, $userid = false, $groupid = false, $showincompletes = 0) {
         global $DB;

--- a/classes/responsetype/text.php
+++ b/classes/responsetype/text.php
@@ -14,29 +14,23 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * This file contains the parent class for questionnaire question types.
- *
- * @author Mike Churchward
- * @license http://www.gnu.org/copyleft/gpl.html GNU Public License
- * @package questiontypes
- */
-
 namespace mod_questionnaire\responsetype;
-defined('MOODLE_INTERNAL') || die();
 
 use mod_questionnaire\db\bulk_sql_config;
 
 /**
  * Class for text response types.
- *
  * @author Mike Churchward
- * @package responsetypes
+ * @copyright 2016 onward Mike Churchward (mike.churchward@poetopensource.org)
+ * @license http://www.gnu.org/copyleft/gpl.html GNU Public License
+ * @package mod_questionnaire
  */
-
 class text extends responsetype {
     /**
-     * @return string
+     * Provide the necessary response data table name. Should probably always be used with late static binding 'static::' form
+     * rather than 'self::' form to allow for class extending.
+     *
+     * @return string response table name.
      */
     public static function response_table() {
         return 'questionnaire_response_text';
@@ -63,10 +57,10 @@ class text extends responsetype {
     }
 
     /**
-     * @param \mod_questionnaire\responsetype\response\response|\stdClass $responsedata
-     * @return bool|int
-     * @throws \coding_exception
-     * @throws \dml_exception
+     * Insert a provided response to the question.
+     *
+     * @param object $responsedata All of the responsedata as an object.
+     * @return int|bool - on error the subtype should call set_error and return false.
      */
     public function insert_response($responsedata) {
         global $DB;
@@ -89,11 +83,11 @@ class text extends responsetype {
     }
 
     /**
-     * @param bool $rids
-     * @param bool $anonymous
-     * @return array
-     * @throws \coding_exception
-     * @throws \dml_exception
+     * Provide the result information for the specified result records.
+     *
+     * @param int|array $rids - A single response id, or array.
+     * @param boolean $anonymous - Whether or not responses are anonymous.
+     * @return array - Array of data records.
      */
     public function get_results($rids=false, $anonymous=false) {
         global $DB;
@@ -141,11 +135,12 @@ class text extends responsetype {
     }
 
     /**
-     * @param bool $rids
-     * @param string $sort
-     * @param bool $anonymous
-     * @return string
-     * @throws \coding_exception
+     * Provide the result information for the specified result records.
+     *
+     * @param int|array $rids - A single response id, or array.
+     * @param string $sort - Optional display sort.
+     * @param boolean $anonymous - Whether or not responses are anonymous.
+     * @return string - Display output.
      */
     public function display_results($rids=false, $sort='', $anonymous=false) {
         if (is_array($rids)) {
@@ -164,15 +159,14 @@ class text extends responsetype {
     }
 
     /**
-     * Override the results tags function for templates for questions with dates.
+     * Gets the results tags for templates for questions with defined choices (single, multiple, boolean).
      *
-     * @param $weights
-     * @param $participants Number of questionnaire participants.
-     * @param $respondents Number of question respondents.
-     * @param $showtotals
+     * @param array $weights
+     * @param int $participants Number of questionnaire participants.
+     * @param int $respondents Number of question respondents.
+     * @param int $showtotals
      * @param string $sort
      * @return \stdClass
-     * @throws \coding_exception
      */
     public function get_results_tags($weights, $participants, $respondents, $showtotals = 1, $sort = '') {
         $pagetags = new \stdClass();

--- a/classes/search/question.php
+++ b/classes/search/question.php
@@ -13,21 +13,17 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
-/**
- * Contains class mod_questionnaire\search\question
- *
- * @package    mod_questionnaire
- * @copyright  2016 Mike Churchward (mike.churchward@poetgroup.org)
- * @author     Mike Churchward
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
+
 namespace mod_questionnaire\search;
-defined('MOODLE_INTERNAL') || die();
+
 /**
+ * Contains the question class definition for search.
+ *
  * Search area for mod_questionnaire questions. Separated from the activity search so that admins can choose whether or not they
  * want this part enabled.
  *
  * @package    mod_questionnaire
+ * @author     Mike Churchward
  * @copyright  2016 Mike Churchward (mike.churchward@poetgroup.org)
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */

--- a/classes/settings_form.php
+++ b/classes/settings_form.php
@@ -14,21 +14,24 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * @package mod_questionnaire
- * @copyright  2016 Mike Churchward (mike.churchward@poetgroup.org)
- * @author     Mike Churchward
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
 namespace mod_questionnaire;
 
 defined('MOODLE_INTERNAL') || die();
 
 require_once($CFG->libdir . '/formslib.php');
 
+/**
+ * The questionnaire settings form.
+ * @package mod_questionnaire
+ * @copyright  2016 Mike Churchward (mike.churchward@poetgroup.org)
+ * @author     Mike Churchward
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
 class settings_form extends \moodleform {
 
+    /**
+     * Defines the form.
+     */
     public function definition() {
         global $questionnaire, $questionnairerealms;
 
@@ -127,6 +130,13 @@ class settings_form extends \moodleform {
 
     }
 
+    /**
+     * Validation rules for form.
+     * @param array $data array of ("fieldname"=>value) of submitted data
+     * @param array $files array of uploaded files "element_name"=>tmp_file_path
+     * @return array of "element_name"=>"error_description" if there are errors,
+     *         or an empty array if everything is OK (true allowed for backwards compatibility too).
+     */
     public function validation($data, $files) {
         $errors = parent::validation($data, $files);
         return $errors;

--- a/classes/task/cleanup.php
+++ b/classes/task/cleanup.php
@@ -14,17 +14,16 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+namespace mod_questionnaire\task;
+
 /**
  * A scheduled task for Questionnaire.
  *
  * @package mod_questionnaire
  * @copyright 2015 The Open University
+ * @author     Mike Churchward
  * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-namespace mod_questionnaire\task;
-
-defined('MOODLE_INTERNAL') || die();
-
 class cleanup extends \core\task\scheduled_task {
 
     /**
@@ -36,6 +35,9 @@ class cleanup extends \core\task\scheduled_task {
         return get_string('crontask', 'mod_questionnaire');
     }
 
+    /**
+     * Execute method.
+     */
     public function execute() {
         global $CFG;
         require_once($CFG->dirroot . '/mod/questionnaire/locallib.php');

--- a/complete.php
+++ b/complete.php
@@ -14,8 +14,15 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-// This page prints a particular instance of questionnaire.
-
+/**
+ * This page prints a particular instance of questionnaire.
+ *
+ * @package mod_questionnaire
+ * @copyright  2016 Mike Churchward (mike.churchward@poetgroup.org)
+ * @author     Mike Churchward
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ *
+ */
 require_once("../../config.php");
 require_once($CFG->libdir . '/completionlib.php');
 require_once($CFG->dirroot.'/mod/questionnaire/questionnaire.class.php');

--- a/complete.php
+++ b/complete.php
@@ -47,7 +47,7 @@ if (isset($id)) {
 
 $PAGE->set_url($url);
 $PAGE->set_context($context);
-$questionnaire = new questionnaire(0, $questionnaire, $course, $cm);
+$questionnaire = new questionnaire( $course, $cm, 0, $questionnaire);
 // Add renderer and page objects to the questionnaire object for display use.
 $questionnaire->add_renderer($PAGE->get_renderer('mod_questionnaire'));
 $questionnaire->add_page(new \mod_questionnaire\output\completepage());

--- a/db/install.php
+++ b/db/install.php
@@ -14,18 +14,19 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/*
- *
- * @package    mod
- * @subpackage questionnaire
+/**
+ * The file containing the install functions.
+ * @package    mod_questionnaire
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  * This file is executed right after the install.xml
- * @copyright  2010 Remote Learner (http://www.remote-learner.net)
+ * @copyright  2016 Mike Churchward (mike.churchward@poetopensource.org)
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-
 defined('MOODLE_INTERNAL') || die();
 
+/**
+ * The install function.
+ */
 function xmldb_questionnaire_install() {
     global $DB;
 

--- a/db/log.php
+++ b/db/log.php
@@ -17,9 +17,8 @@
 /**
  * Capability definitions for the quiz module.
  *
- * @package    mod
- * @subpackage questionnaire
- * @copyright  2010 Remote-Learner.net (http://www.remote-learner.net)
+ * @package    mod_questionnaire
+ * @copyright  2016 Mike Churchward (mike.churchward@poetopensource.org)
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/db/tasks.php
+++ b/db/tasks.php
@@ -16,6 +16,7 @@
 
 /**
  * Definition of Questionnaire scheduled tasks.
+ *
  * Default is to run once every 12 hours.
  *
  * @package mod_questionnaire
@@ -23,9 +24,9 @@
  * @copyright 2015 The Open University
  * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-
 defined('MOODLE_INTERNAL') || die();
 
+/** @var array $tasks */
 $tasks = array(
     array(
         'classname' => 'mod_questionnaire\task\cleanup',

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -15,14 +15,20 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
+ * The file containing the upgrade functions.
  * @package mod_questionnaire
- * @copyright  2016 Mike Churchward (mike.churchward@poetgroup.org)
+ * @copyright  2016 Mike Churchward (mike.churchward@poetopensource.org)
  * @author     Mike Churchward
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
 defined('MOODLE_INTERNAL') || die();
 
+/**
+ * The module upgrade function.
+ * @param int $oldversion
+ * @return bool
+ */
 function xmldb_questionnaire_upgrade($oldversion=0) {
     global $CFG, $DB;
 
@@ -982,7 +988,10 @@ function xmldb_questionnaire_upgrade($oldversion=0) {
     return $result;
 }
 
-// Supporting functions used once.
+/**
+ * Supporting functions used once.
+ * @return bool
+ */
 function questionnaire_upgrade_2007120101() {
     global $DB;
 

--- a/drawchart.php
+++ b/drawchart.php
@@ -23,8 +23,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-function draw_chart($feedbacktype, $charttype=null, $labels,
-                    $score=null, $allscore=null, $globallabel=null, $groupname, $allresponses) {
+function draw_chart($feedbacktype, $labels, $groupname,
+                    $allresponses, $charttype=null, $score=null, $allscore=null, $globallabel=null) {
     global $PAGE;
 
     $pageoutput = '';

--- a/drawchart.php
+++ b/drawchart.php
@@ -15,6 +15,7 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
+ * Library draw chart function.
  * @package mod_questionnaire
  * @copyright  2016 Mike Churchward (mike.churchward@poetgroup.org)
  * @author     Mike Churchward
@@ -23,6 +24,18 @@
 
 defined('MOODLE_INTERNAL') || die();
 
+/**
+ * This is the function.
+ * @param string $feedbacktype
+ * @param array $labels
+ * @param string $groupname
+ * @param bool $allresponses
+ * @param null|string $charttype
+ * @param null|array $score
+ * @param null|array $allscore
+ * @param null|string $globallabel
+ * @return string
+ */
 function draw_chart($feedbacktype, $labels, $groupname,
                     $allresponses, $charttype=null, $score=null, $allscore=null, $globallabel=null) {
     global $PAGE;

--- a/externallib.php
+++ b/externallib.php
@@ -104,7 +104,7 @@ class mod_questionnaire_external extends \external_api {
         );
 
         list($cm, $course, $questionnaire) = questionnaire_get_standard_page_items($cmid);
-        $questionnaire = new \questionnaire(0, $questionnaire, $course, $cm);
+        $questionnaire = new \questionnaire($course, $cm, 0, $questionnaire);
 
         $context = \context_module::instance($cm->id);
         self::validate_context($context);

--- a/externallib.php
+++ b/externallib.php
@@ -82,9 +82,9 @@ class mod_questionnaire_external extends \external_api {
      * @param int $completed Completed survey 1/0
      * @param int $rid Already in progress response id.
      * @param int $submit Submit survey?
+     * @param string $action
      * @param array $responses the response ids
      * @return array answers information and warnings
-     * @since Moodle 3.0
      */
     public static function submit_questionnaire_response($questionnaireid, $surveyid, $userid, $cmid, $sec, $completed, $rid,
                                                          $submit, $action, $responses) {

--- a/fbsections.php
+++ b/fbsections.php
@@ -58,11 +58,11 @@ if (!isset($SESSION->questionnaire)) {
     $SESSION->questionnaire = new stdClass();
 }
 
-$questionnaire = new questionnaire(0, $questionnaire, $course, $cm);
+$questionnaire = new questionnaire($course, $cm, 0, $questionnaire);
 
 if ($sectionid) {
     // Get the specified section by its id.
-    $feedbacksection = new mod_questionnaire\feedback\section(['id' => $sectionid], $questionnaire->questions);
+    $feedbacksection = new mod_questionnaire\feedback\section($questionnaire->questions, ['id' => $sectionid]);
 
 } else if (!$DB->count_records('questionnaire_fb_sections', ['surveyid' => $questionnaire->sid])) {
     // There are no sections currently, so create one.
@@ -75,8 +75,8 @@ if ($sectionid) {
 
 } else {
     // Get the specified section by section number.
-    $feedbacksection = new mod_questionnaire\feedback\section(['surveyid' => $questionnaire->survey->id, 'sectionnum' => $section],
-        $questionnaire->questions);
+    $feedbacksection = new mod_questionnaire\feedback\section($questionnaire->questions,
+        ['surveyid' => $questionnaire->survey->id, 'sectionnum' => $section]);
 }
 
 // Get all questions that are valid feedback questions.

--- a/feedback.php
+++ b/feedback.php
@@ -53,7 +53,7 @@ $PAGE->set_context($context);
 if (!isset($SESSION->questionnaire)) {
     $SESSION->questionnaire = new stdClass();
 }
-$questionnaire = new questionnaire(0, $questionnaire, $course, $cm);
+$questionnaire = new questionnaire($course, $cm, 0, $questionnaire);
 
 // Add renderer and page objects to the questionnaire object for display use.
 $questionnaire->add_renderer($PAGE->get_renderer('mod_questionnaire'));

--- a/index.php
+++ b/index.php
@@ -17,12 +17,10 @@
 /**
  * This script lists all the instances of questionnaire in a particular course
  *
- * @package    mod
- * @subpackage questionnaire
- * @copyright  1999 onwards Martin Dougiamas  {@link http://moodle.com}
+ * @package    mod_questionnaire
+ * @copyright  2016 Mike Churchward (mike.churchward@poetopensource.org)
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-
 
 require_once("../../config.php");
 require_once($CFG->dirroot.'/mod/questionnaire/locallib.php');

--- a/lib.php
+++ b/lib.php
@@ -14,20 +14,25 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-// Library of functions and constants for module questionnaire.
-
 /**
+ * Library of functions and constants for module questionnaire.
  * @package mod_questionnaire
- * @copyright  2016 Mike Churchward (mike.churchward@poetgroup.org)
+ * @copyright  2016 Mike Churchward (mike.churchward@poetopensource.org)
  * @author     Mike Churchward
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-defined('MOODLE_INTERNAL') || die();
-
+/** This may no longer be needed. */
 define('QUESTIONNAIRE_RESETFORM_RESET', 'questionnaire_reset_data_');
+
+/** This may no longer be needed. */
 define('QUESTIONNAIRE_RESETFORM_DROP', 'questionnaire_drop_questionnaire_');
 
+/**
+ * Library supports implementation.
+ * @param string $feature
+ * @return bool|null
+ */
 function questionnaire_supports($feature) {
     switch($feature) {
         case FEATURE_BACKUP_MOODLE2:
@@ -55,17 +60,28 @@ function questionnaire_supports($feature) {
 }
 
 /**
+ * Return any extra capabilities.
  * @return array all other caps used in module
  */
 function questionnaire_get_extra_capabilities() {
     return array('moodle/site:accessallgroups');
 }
 
+/**
+ * Implementation of get_instance.
+ * @param int $questionnaireid
+ * @return false|mixed|stdClass
+ */
 function questionnaire_get_instance($questionnaireid) {
     global $DB;
     return $DB->get_record('questionnaire', array('id' => $questionnaireid));
 }
 
+/**
+ * Implementation of add_instance.
+ * @param stdClass $questionnaire
+ * @return bool|int
+ */
 function questionnaire_add_instance($questionnaire) {
     // Given an object containing all the necessary data,
     // (defined by the form in mod.html) this function
@@ -150,9 +166,12 @@ function questionnaire_add_instance($questionnaire) {
     return $questionnaire->id;
 }
 
-// Given an object containing all the necessary data,
-// (defined by the form in mod.html) this function
-// will update an existing instance with new data.
+/**
+ * Given an object containing all the necessary data, (defined by the form in mod.html) this function will update an existing
+ * instance with new data.
+ * @param stdClass $questionnaire
+ * @return bool
+ */
 function questionnaire_update_instance($questionnaire) {
     global $DB, $CFG;
     require_once($CFG->dirroot.'/mod/questionnaire/locallib.php');
@@ -183,9 +202,11 @@ function questionnaire_update_instance($questionnaire) {
     return $DB->update_record("questionnaire", $questionnaire);
 }
 
-// Given an ID of an instance of this module,
-// this function will permanently delete the instance
-// and any data that depends on it.
+/**
+ * Given an ID of an instance of this module, this function will permanently delete the instance and any data that depends on it.
+ * @param int $id
+ * @return bool
+ */
 function questionnaire_delete_instance($id) {
     global $DB, $CFG;
     require_once($CFG->dirroot.'/mod/questionnaire/locallib.php');
@@ -217,15 +238,17 @@ function questionnaire_delete_instance($id) {
     return $result;
 }
 
-// Return a small object with summary information about what a
-// user has done with a given particular instance of this module
-// Used for user activity reports.
-// $return->time = the time they did it
-// $return->info = a short text description.
 /**
+ * Return a small object with summary information about what a user has done with a given particular instance of this module.
+ * Used for user activity reports.
+ * $return->time = the time they did it
+ * $return->info = a short text description.
  * $course and $mod are unused, but API requires them. Suppress PHPMD warning.
- *
- * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+ * @param stdClass $course
+ * @param stdClass $user
+ * @param stdClass $mod
+ * @param stdClass $questionnaire
+ * @return stdClass
  */
 function questionnaire_user_outline($course, $user, $mod, $questionnaire) {
     global $CFG;
@@ -247,12 +270,15 @@ function questionnaire_user_outline($course, $user, $mod, $questionnaire) {
     return $result;
 }
 
-// Print a detailed representation of what a  user has done with
-// a given particular instance of this module, for user activity reports.
 /**
+ * Print a detailed representation of what a  user has done with a given particular instance of this module, for user
+ * activity reports.
  * $course and $mod are unused, but API requires them. Suppress PHPMD warning.
- *
- * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+ * @param stdClass $course
+ * @param stdClass $user
+ * @param stdClass $mod
+ * @param stdClass $questionnaire
+ * @return bool
  */
 function questionnaire_user_complete($course, $user, $mod, $questionnaire) {
     global $CFG;
@@ -273,24 +299,25 @@ function questionnaire_user_complete($course, $user, $mod, $questionnaire) {
     return true;
 }
 
-// Given a course and a time, this module should find recent activity
-// that has occurred in questionnaire activities and print it out.
-// Return true if there was output, or false is there was none.
 /**
+ * Given a course and a time, this module should find recent activity that has occurred in questionnaire activities and print it
+ * out.
+ * Return true if there was output, or false is there was none.
  * $course, $isteacher and $timestart are unused, but API requires them. Suppress PHPMD warning.
- *
- * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+ * @param stdClass $course
+ * @param bool $isteacher
+ * @param int $timestart
+ * @return false
  */
 function questionnaire_print_recent_activity($course, $isteacher, $timestart) {
     return false;  // True if anything was printed, otherwise false.
 }
 
-// Must return an array of grades for a given instance of this module,
-// indexed by user.  It also returns a maximum allowed grade.
 /**
+ * Must return an array of grades for a given instance of this module, indexed by user.  It also returns a maximum allowed grade.
  * $questionnaireid is unused, but API requires it. Suppress PHPMD warning.
- *
- * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+ * @param int $questionnaireid
+ * @return null
  */
 function questionnaire_grades($questionnaireid) {
     return null;
@@ -299,7 +326,7 @@ function questionnaire_grades($questionnaireid) {
 /**
  * Return grade for given user or all users.
  *
- * @param int $questionnaireid id of assignment
+ * @param stdClass $questionnaire
  * @param int $userid optional user id, 0 means all users
  * @return array array of grades, false if none
  */
@@ -319,14 +346,11 @@ function questionnaire_get_user_grades($questionnaire, $userid=0) {
 }
 
 /**
- * Update grades by firing grade_updated event
- *
- * @param object $assignment null means all assignments
- * @param int $userid specific user only, 0 mean all
- *
+ * Update grades by firing grade_updated event.
  * $nullifnone is unused, but API requires it. Suppress PHPMD warning.
- *
- * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+ * @param stdClass $questionnaire
+ * @param int $userid
+ * @param bool $nullifnone
  */
 function questionnaire_update_grades($questionnaire=null, $userid=0, $nullifnone=true) {
     global $CFG, $DB;
@@ -376,8 +400,8 @@ function questionnaire_update_grades($questionnaire=null, $userid=0, $nullifnone
 /**
  * Create grade item for given questionnaire
  *
- * @param object $questionnaire object with extra cmidnumber
- * @param mixed optional array/object of grade(s); 'reset' means reset grades in gradebook
+ * @param stdClass $questionnaire object with extra cmidnumber
+ * @param mixed $grades optional array/object of grade(s); 'reset' means reset grades in gradebook
  * @return int 0 if ok, error code otherwise
  */
 function questionnaire_grade_item_update($questionnaire, $grades = null) {
@@ -427,13 +451,11 @@ function questionnaire_grade_item_update($questionnaire, $grades = null) {
  * it it has support for grading and scales. Commented code should be
  * modified if necessary. See forum, glossary or journal modules
  * as reference.
- * @param $questionnaireid int
- * @param $scaleid int
+ * @param int $questionnaireid
+ * @param int $scaleid
  * @return boolean True if the scale is used by any questionnaire
  *
  * Function parameters are unused, but API requires them. Suppress PHPMD warning.
- *
- * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 function questionnaire_scale_used ($questionnaireid, $scaleid) {
     return false;
@@ -443,12 +465,10 @@ function questionnaire_scale_used ($questionnaireid, $scaleid) {
  * Checks if scale is being used by any instance of questionnaire
  *
  * This is used to find out if scale used anywhere
- * @param $scaleid int
+ * @param int $scaleid
  * @return boolean True if the scale is used by any questionnaire
  *
  * Function parameters are unused, but API requires them. Suppress PHPMD warning.
- *
- * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 function questionnaire_scale_used_anywhere($scaleid) {
     return false;
@@ -457,17 +477,15 @@ function questionnaire_scale_used_anywhere($scaleid) {
 /**
  * Serves the questionnaire attachments. Implements needed access control ;-)
  *
- * @param object $course
- * @param object $cm
- * @param object $context
+ * @param stdClass $course
+ * @param stdClass $cm
+ * @param stdClass $context
  * @param string $filearea
  * @param array $args
  * @param bool $forcedownload
  * @return bool false if file not found, does not return if found - justsend the file
  *
  * $forcedownload is unused, but API requires it. Suppress PHPMD warning.
- *
- * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 function questionnaire_pluginfile($course, $cm, $context, $filearea, $args, $forcedownload) {
     global $DB;
@@ -524,8 +542,6 @@ function questionnaire_pluginfile($course, $cm, $context, $filearea, $args, $for
  * @param navigation_node $questionnairenode The node to add module settings to
  *
  * $settings is unused, but API requires it. Suppress PHPMD warning.
- *
- * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 function questionnaire_extend_settings_navigation(settings_navigation $settings,
         navigation_node $questionnairenode) {
@@ -738,16 +754,35 @@ function questionnaire_extend_settings_navigation(settings_navigation $settings,
 // Any other questionnaire functions go here.  Each of them must have a name that
 // starts with questionnaire_.
 
+/**
+ * Return the view actions.
+ * @return string[]
+ */
 function questionnaire_get_view_actions() {
     return array('view', 'view all');
 }
 
+/**
+ * Return the post actions.
+ * @return string[]
+ */
 function questionnaire_get_post_actions() {
     return array('submit', 'update');
 }
 
+/**
+ * Return the recent activity.
+ * @param array $activities
+ * @param int $index
+ * @param int $timestart
+ * @param int $courseid
+ * @param int $cmid
+ * @param int $userid
+ * @param int $groupid
+ * @return mixed|void
+ */
 function questionnaire_get_recent_mod_activity(&$activities, &$index, $timestart,
-                $courseid, $cmid, $userid = 0, $groupid = 0) {
+                                               $courseid, $cmid, $userid = 0, $groupid = 0) {
 
     global $CFG, $COURSE, $USER, $DB;
     require_once($CFG->dirroot . '/mod/questionnaire/locallib.php');
@@ -911,16 +946,13 @@ function questionnaire_get_recent_mod_activity(&$activities, &$index, $timestart
 /**
  * Prints all users who have completed a specified questionnaire since a given time
  *
- * @global object
- * @param object $activity
+ * @param stdClass $activity
  * @param int $courseid
  * @param string $detail not used but needed for compability
  * @param array $modnames
  * @return void Output is echo'd
  *
  * $details and $modenames are unused, but API requires them. Suppress PHPMD warning.
- *
- * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 function questionnaire_print_recent_mod_activity($activity, $courseid, $detail, $modnames) {
     global $OUTPUT;
@@ -989,10 +1021,6 @@ function questionnaire_print_recent_mod_activity($activity, $courseid, $detail, 
  * questionnaires that have a deadline that has not already passed
  * and it is available for taking.
  *
- * @global object
- * @global stdClass
- * @global object
- * @uses CONTEXT_MODULE
  * @param array $courses An array of course objects to get questionnaire instances from
  * @param array $htmlarray Store overview output array( course ID => 'questionnaire' => HTML output )
  * @return void
@@ -1077,7 +1105,7 @@ function questionnaire_print_overview($courses, &$htmlarray) {
  * Implementation of the function for printing the form elements that control
  * whether the course reset functionality affects the questionnaire.
  *
- * @param $mform the course reset form that is being built.
+ * @param stdClass $mform the course reset form that is being built.
  */
 function questionnaire_reset_course_form_definition($mform) {
     $mform->addElement('header', 'questionnaireheader', get_string('modulenameplural', 'questionnaire'));
@@ -1087,11 +1115,10 @@ function questionnaire_reset_course_form_definition($mform) {
 
 /**
  * Course reset form defaults.
+ * @param stdClass $course
  * @return array the defaults.
  *
  * Function parameters are unused, but API requires them. Suppress PHPMD warning.
- *
- * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 function questionnaire_reset_course_form_defaults($course) {
     return array('reset_questionnaire' => 1);
@@ -1101,7 +1128,7 @@ function questionnaire_reset_course_form_defaults($course) {
  * Actual implementation of the reset course functionality, delete all the
  * questionnaire responses for course $data->courseid.
  *
- * @param object $data the data submitted from the reset course.
+ * @param stdClass $data the data submitted from the reset course.
  * @return array status array
  */
 function questionnaire_reset_userdata($data) {
@@ -1157,15 +1184,13 @@ function questionnaire_reset_userdata($data) {
  * Obtains the automatic completion state for this questionnaire based on the condition
  * in questionnaire settings.
  *
- * @param object $course Course
- * @param object $cm Course-module
+ * @param stdClass $course Course
+ * @param stdClass $cm Course-module
  * @param int $userid User ID
  * @param bool $type Type of comparison (or/and; can be used as return value if no conditions)
  * @return bool True if completed, false if not, $type if conditions not set.
  *
  * $course is unused, but API requires it. Suppress PHPMD warning.
- *
- * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 function questionnaire_get_completion_state($course, $cm, $userid, $type) {
     global $DB;
@@ -1217,8 +1242,8 @@ function mod_questionnaire_core_calendar_provide_event_action(calendar_event $ev
  * Called after the activity and module have been created. Use this to copy any images if the questionnaire was created from another
  * questionnaire survey.
  *
- * @param $data
- * @param $course
+ * @param stdClass $data
+ * @param stdClass $course
  * @throws coding_exception
  */
 function mod_questionnaire_coursemodule_edit_post_actions($data, $course) {

--- a/lib.php
+++ b/lib.php
@@ -82,7 +82,7 @@ function questionnaire_add_instance($questionnaire) {
         // Create a new survey.
         $course = get_course($questionnaire->course);
         $cm = new stdClass();
-        $qobject = new questionnaire(0, $questionnaire, $course, $cm);
+        $qobject = new questionnaire($course, $cm, 0, $questionnaire);
 
         if ($questionnaire->create == 'new-0') {
             $sdata = new stdClass();
@@ -547,7 +547,7 @@ function questionnaire_extend_settings_navigation(settings_navigation $settings,
     }
 
     $courseid = $course->id;
-    $questionnaire = new questionnaire(0, $questionnaire, $course, $cm);
+    $questionnaire = new questionnaire($course, $cm, 0, $questionnaire);
 
     if ($owner = $DB->get_field('questionnaire_survey', 'courseid', ['id' => $questionnaire->sid])) {
         $owner = (trim($owner) == trim($courseid));
@@ -763,7 +763,7 @@ function questionnaire_get_recent_mod_activity(&$activities, &$index, $timestart
 
     $cm = $modinfo->cms[$cmid];
     $questionnaire = $DB->get_record('questionnaire', ['id' => $cm->instance]);
-    $questionnaire = new questionnaire(0, $questionnaire, $course, $cm);
+    $questionnaire = new questionnaire($course, $cm, 0, $questionnaire);
 
     $context = context_module::instance($cm->id);
     $grader = has_capability('mod/questionnaire:viewsingleresponse', $context);
@@ -1226,10 +1226,10 @@ function mod_questionnaire_coursemodule_edit_post_actions($data, $course) {
 
     if (!empty($data->copyid)) {
         $cm = (object)['id' => $data->coursemodule];
-        $questionnaire = new questionnaire(0, $data, $course, $cm);
+        $questionnaire = new questionnaire($course, $cm, 0, $data);
         $oldquestionnaireid = $DB->get_field('questionnaire', 'id', ['sid' => $data->copyid]);
         $oldcm = get_coursemodule_from_instance('questionnaire', $oldquestionnaireid);
-        $oldquestionnaire = new questionnaire($oldquestionnaireid, null, $course, $oldcm);
+        $oldquestionnaire = new questionnaire($course, $oldcm, $oldquestionnaireid, null);
         $oldcontext = context_module::instance($oldcm->id);
         $newcontext = context_module::instance($data->coursemodule);
         $areas = $questionnaire->get_all_file_areas();

--- a/locallib.php
+++ b/locallib.php
@@ -15,27 +15,16 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
+ * Updates the contents of the survey with the provided data. If no data is provided, it checks for posted data.
+ *
  * This library replaces the phpESP application with Moodle specific code. It will eventually
  * replace all of the phpESP application, removing the dependency on that.
- */
-
-/**
- * Updates the contents of the survey with the provided data. If no data is provided,
- * it checks for posted data.
  *
- * @param int $surveyid The id of the survey to update.
- * @param string $old_tab The function that was being executed.
- * @param object $sdata The data to update the survey with.
- *
- * @return string|boolean The function to go to, or false on error.
- *
- */
-
-/**
  * @package mod_questionnaire
  * @copyright  2016 Mike Churchward (mike.churchward@poetgroup.org)
  * @author     Mike Churchward
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ *
  */
 
 defined('MOODLE_INTERNAL') || die();
@@ -87,6 +76,11 @@ $autonumbering = array (0 => get_string('autonumberno', 'questionnaire'),
         2 => get_string('autonumberpages', 'questionnaire'),
         3 => get_string('autonumberpagesandquestions', 'questionnaire'));
 
+/**
+ * Return the choice values for the content.
+ * @param string $content
+ * @return stdClass
+ */
 function questionnaire_choice_values($content) {
 
     // If we run the content through format_text first, any filters we want to use (e.g. multilanguage) should work.
@@ -157,7 +151,11 @@ function questionnaire_get_js_module() {
 }
 
 /**
- * Get all the questionnaire responses for a user
+ * Get all the questionnaire responses for a user.
+ * @param int $questionnaireid
+ * @param int $userid
+ * @param bool $complete
+ * @return array
  */
 function questionnaire_get_user_responses($questionnaireid, $userid, $complete=true) {
     global $DB;
@@ -227,8 +225,12 @@ function questionnaire_get_context($cmid) {
     return $context;
 }
 
-// This function *really* shouldn't be needed, but since sometimes we can end up with
-// orphaned surveys, this will clean them up.
+/**
+ * This function *really* shouldn't be needed, but since sometimes we can end up with
+ * orphaned surveys, this will clean them up.
+ * @return bool
+ * @throws dml_exception
+ */
 function questionnaire_cleanup() {
     global $DB;
 
@@ -246,6 +248,12 @@ function questionnaire_cleanup() {
     return true;
 }
 
+/**
+ * Delete the survey.
+ * @param int $sid
+ * @param int $questionnaireid
+ * @return bool
+ */
 function questionnaire_delete_survey($sid, $questionnaireid) {
     global $DB;
     $status = true;
@@ -283,6 +291,12 @@ function questionnaire_delete_survey($sid, $questionnaireid) {
     return $status;
 }
 
+/**
+ * Delete the response.
+ * @param stdClass $response
+ * @param string $questionnaire
+ * @return bool
+ */
 function questionnaire_delete_response($response, $questionnaire='') {
     global $DB;
     $status = true;
@@ -315,6 +329,11 @@ function questionnaire_delete_response($response, $questionnaire='') {
     return $status;
 }
 
+/**
+ * Delete all responses for the questionnaire.
+ * @param int $qid
+ * @return bool
+ */
 function questionnaire_delete_responses($qid) {
     global $DB;
 
@@ -330,6 +349,11 @@ function questionnaire_delete_responses($qid) {
     return true;
 }
 
+/**
+ * Delete all dependencies for the questionnaire.
+ * @param int $qid
+ * @return bool
+ */
 function questionnaire_delete_dependencies($qid) {
     global $DB;
 
@@ -340,6 +364,12 @@ function questionnaire_delete_dependencies($qid) {
     return true;
 }
 
+/**
+ * Get a survey selection records.
+ * @param int $courseid
+ * @param string $type
+ * @return array|false
+ */
 function questionnaire_get_survey_list($courseid=0, $type='') {
     global $DB;
 
@@ -389,6 +419,12 @@ function questionnaire_get_survey_list($courseid=0, $type='') {
     return $DB->get_records_sql($sql, $params);
 }
 
+/**
+ * Get survey selection list.
+ * @param int $courseid
+ * @param string $type
+ * @return array
+ */
 function questionnaire_get_survey_select($courseid=0, $type='') {
     global $OUTPUT, $DB;
 
@@ -425,6 +461,12 @@ function questionnaire_get_survey_select($courseid=0, $type='') {
     return $surveylist;
 }
 
+/**
+ * Return the language string for the specified question type.
+ * @param int $id
+ * @return lang_string|mixed|string
+ * @throws coding_exception
+ */
 function questionnaire_get_type ($id) {
     switch ($id) {
         case 1:
@@ -459,8 +501,6 @@ function questionnaire_get_type ($id) {
  * @param object $questionnaire
  * @return void
  */
- /* added by JR 16 march 2009 based on lesson_process_post_save script */
-
 function questionnaire_set_events($questionnaire) {
     // Adding the questionnaire to the eventtable.
     global $DB;
@@ -512,14 +552,15 @@ function questionnaire_set_events($questionnaire) {
 /**
  * Get users who have not completed the questionnaire
  *
- * @global object
- * @uses CONTEXT_MODULE
  * @param object $cm
- * @param int $group single groupid
+ * @param int $sid
+ * @param bool $group single groupid
  * @param string $sort
- * @param int $startpage
- * @param int $pagecount
+ * @param bool $startpage
+ * @param bool $pagecount
  * @return object the userrecords
+ * @throws coding_exception
+ * @throws dml_exception
  */
 function questionnaire_get_incomplete_users($cm, $sid,
                 $group = false,
@@ -569,6 +610,8 @@ function questionnaire_get_incomplete_users($cm, $sid,
 /**
  * Called by HTML editor in showrespondents and Essay question. Based on question/essay/renderer.
  * Pending general solution to using the HTML editor outside of moodleforms in Moodle pages.
+ * @param int $context
+ * @return array
  */
 function questionnaire_get_editor_options($context) {
     return array(
@@ -581,8 +624,11 @@ function questionnaire_get_editor_options($context) {
     );
 }
 
-// Get the parent of a child question.
-// TODO - This needs to be refactored or removed.
+/**
+ * Get the parent of a child question.
+ * @param stdClass $question
+ * @return array
+ */
 function questionnaire_get_parent ($question) {
     global $DB;
     $qid = $question->id;
@@ -688,7 +734,11 @@ function questionnaire_get_child_positions ($questions) {
     return $childpositions;
 }
 
-// Check that the needed page breaks are present to separate child questions.
+/**
+ * Check that the needed page breaks are present to separate child questions.
+ * @param stdClass $questionnaire
+ * @return false|lang_string|string
+ */
 function questionnaire_check_page_breaks($questionnaire) {
     global $DB;
     $msg = '';
@@ -805,6 +855,10 @@ function questionnaire_check_page_breaks($questionnaire) {
 
 /**
  * Code snippet used to set up the questionform.
+ * @param stdClass $questionnaire
+ * @param int $qid
+ * @param int $qtype
+ * @return mixed|\mod_questionnaire\question\question
  */
 function questionnaire_prep_for_questionform($questionnaire, $qid, $qtype) {
     $context = context_module::instance($questionnaire->cm->id);

--- a/locallib.php
+++ b/locallib.php
@@ -784,7 +784,7 @@ function questionnaire_check_page_breaks($questionnaire) {
                     }
                     $newpbids[] = $newqid;
                     $movetopos = $i;
-                    $questionnaire = new questionnaire($questionnaire->id, null, $course, $cm);
+                    $questionnaire = new questionnaire($course, $cm, $questionnaire->id, null);
                     $questionnaire->move_question($newqid, $movetopos);
                 }
             }
@@ -795,7 +795,7 @@ function questionnaire_check_page_breaks($questionnaire) {
     } else if ($newpbids) {
         $msg .= get_string('checkbreaksadded', 'questionnaire').'&nbsp;';
         $newpbids = array_reverse ($newpbids);
-        $questionnaire = new questionnaire($questionnaire->id, null, $course, $cm);
+        $questionnaire = new questionnaire($course, $cm, $questionnaire->id, null);
         foreach ($newpbids as $newpbid) {
             $msg .= $questionnaire->questions[$newpbid]->position.'&nbsp;';
         }

--- a/mod_form.php
+++ b/mod_form.php
@@ -14,22 +14,25 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * print the form to add or edit a questionnaire-instance
- *
- * @author Mike Churchward
- * @license http://www.gnu.org/copyleft/gpl.html GNU Public License
- * @package questionnaire
- */
-
 defined('MOODLE_INTERNAL') || die();
 
 require_once($CFG->dirroot.'/course/moodleform_mod.php');
 require_once($CFG->dirroot.'/mod/questionnaire/questionnaire.class.php');
 require_once($CFG->dirroot.'/mod/questionnaire/locallib.php');
 
+/**
+ * print the form to add or edit a questionnaire-instance
+ *
+ * @package mod_questionnaire
+ * @author Mike Churchward
+ * @copyright  2016 onward Mike Churchward (mike.churchward@poetgroup.org)
+ * @license http://www.gnu.org/copyleft/gpl.html GNU Public License
+ */
 class mod_questionnaire_mod_form extends moodleform_mod {
 
+    /**
+     * Form definition.
+     */
     protected function definition() {
         global $COURSE;
         global $questionnairetypes, $questionnairerespondents, $questionnaireresponseviewers, $autonumbering;
@@ -145,6 +148,10 @@ class mod_questionnaire_mod_form extends moodleform_mod {
         $this->add_action_buttons();
     }
 
+    /**
+     * Pre-process form data.
+     * @param array $defaultvalues
+     */
     public function data_preprocessing(&$defaultvalues) {
         global $DB;
         if (empty($defaultvalues['opendate'])) {
@@ -171,7 +178,6 @@ class mod_questionnaire_mod_form extends moodleform_mod {
 
     /**
      * Enforce validation rules here
-     *
      * @param array $data array of ("fieldname"=>value) of submitted data
      * @param array $files array of uploaded files "element_name"=>tmp_file_path
      * @return array
@@ -188,12 +194,21 @@ class mod_questionnaire_mod_form extends moodleform_mod {
         return $errors;
     }
 
+    /**
+     * Add any completion rules for the form.
+     * @return string[]
+     */
     public function add_completion_rules() {
         $mform =& $this->_form;
         $mform->addElement('checkbox', 'completionsubmit', '', get_string('completionsubmit', 'questionnaire'));
         return array('completionsubmit');
     }
 
+    /**
+     * True if the completion rule is enabled.
+     * @param array $data
+     * @return bool
+     */
     public function completion_rule_enabled($data) {
         return !empty($data['completionsubmit']);
     }

--- a/mod_form.php
+++ b/mod_form.php
@@ -34,7 +34,7 @@ class mod_questionnaire_mod_form extends moodleform_mod {
         global $COURSE;
         global $questionnairetypes, $questionnairerespondents, $questionnaireresponseviewers, $autonumbering;
 
-        $questionnaire = new questionnaire($this->_instance, null, $COURSE, $this->_cm);
+        $questionnaire = new questionnaire($COURSE, $this->_cm, $this->_instance, null);
 
         $mform    =& $this->_form;
 

--- a/myreport.php
+++ b/myreport.php
@@ -65,7 +65,7 @@ $PAGE->set_context($context);
 $PAGE->set_title(get_string('questionnairereport', 'questionnaire'));
 $PAGE->set_heading(format_string($course->fullname));
 
-$questionnaire = new questionnaire(0, $questionnaire, $course, $cm);
+$questionnaire = new questionnaire($course, $cm, 0, $questionnaire);
 // Add renderer and page objects to the questionnaire object for display use.
 $questionnaire->add_renderer($PAGE->get_renderer('mod_questionnaire'));
 $questionnaire->add_page(new \mod_questionnaire\output\reportpage());

--- a/myreport.php
+++ b/myreport.php
@@ -14,8 +14,15 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-// This page shows results of a questionnaire to a student.
-
+/**
+ * This page shows results of a questionnaire to a student.
+ *
+ * @package mod_questionnaire
+ * @copyright  2016 Mike Churchward (mike.churchward@poetgroup.org)
+ * @author     Mike Churchward
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ *
+ */
 require_once("../../config.php");
 require_once($CFG->dirroot.'/mod/questionnaire/questionnaire.class.php');
 

--- a/preview.php
+++ b/preview.php
@@ -14,7 +14,14 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-// This page displays a non-completable instance of questionnaire.
+/**
+ * This page displays a non-completable instance of questionnaire.
+ *
+ * @package    mod_questionnaire
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @copyright  2016 onward Mike Churchward (mike.churchward@poetgroup.org)
+ * @author     Mike Churchward
+ */
 
 require_once("../../config.php");
 require_once($CFG->dirroot.'/mod/questionnaire/questionnaire.class.php');

--- a/preview.php
+++ b/preview.php
@@ -79,7 +79,7 @@ $PAGE->set_url($url);
 $PAGE->set_context($context);
 $PAGE->set_cm($cm);   // CONTRIB-5872 - I don't know why this is needed.
 
-$questionnaire = new questionnaire($qid, $questionnaire, $course, $cm);
+$questionnaire = new questionnaire($course, $cm, $qid, $questionnaire);
 
 // Add renderer and page objects to the questionnaire object for display use.
 $questionnaire->add_renderer($PAGE->get_renderer('mod_questionnaire'));
@@ -141,7 +141,7 @@ if ($questionnaire->capabilities->printblank) {
         $questionnaire->renderer->action_link($link, $linkname, $action, array('class' => $class, 'title' => $title),
             new pix_icon('t/print', $title)));
 }
-$questionnaire->survey_print_render('', 'preview', $course->id, $rid = 0, $popup);
+$questionnaire->survey_print_render($course->id, '', 'preview', $rid = 0, $popup);
 if ($popup) {
     $questionnaire->page->add_to_page('closebutton', $questionnaire->renderer->close_window_button());
 }

--- a/print.php
+++ b/print.php
@@ -37,7 +37,7 @@ if (! $cm = get_coursemodule_from_instance("questionnaire", $questionnaire->id, 
 // Check login and get context.
 require_login($courseid);
 
-$questionnaire = new questionnaire(0, $questionnaire, $course, $cm);
+$questionnaire = new questionnaire($course, $cm, 0, $questionnaire);
 
 // Add renderer and page objects to the questionnaire object for display use.
 $questionnaire->add_renderer($PAGE->get_renderer('mod_questionnaire'));
@@ -66,6 +66,6 @@ $PAGE->set_title($questionnaire->survey->title);
 $PAGE->set_pagelayout('popup');
 echo $questionnaire->renderer->header();
 $questionnaire->page->add_to_page('closebutton', $questionnaire->renderer->close_window_button());
-$questionnaire->survey_print_render('', 'print', $courseid, $rid, $blankquestionnaire);
+$questionnaire->survey_print_render($courseid, '', 'print', $rid, $blankquestionnaire);
 echo $questionnaire->renderer->render($questionnaire->page);
 echo $questionnaire->renderer->footer();

--- a/print.php
+++ b/print.php
@@ -14,6 +14,15 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+/**
+ * The main page to print a questionnaire.
+ *
+ * @package mod_questionnaire
+ * @copyright  2016 Mike Churchward (mike.churchward@poetgroup.org)
+ * @author     Mike Churchward
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ *
+ */
 require_once("../../config.php");
 require_once($CFG->dirroot.'/mod/questionnaire/questionnaire.class.php');
 

--- a/qsettings.php
+++ b/qsettings.php
@@ -14,7 +14,13 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-// This page prints a particular instance of questionnaire.
+/**
+ * This page handles the question settings.
+ *
+ * @package    mod_questionnaire
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @copyright  2016 Mike Churchward (mike.churchward@poetopensource.org)
+ */
 
 require_once("../../config.php");
 require_once($CFG->dirroot.'/mod/questionnaire/questionnaire.class.php');

--- a/qsettings.php
+++ b/qsettings.php
@@ -46,7 +46,7 @@ $PAGE->set_context($context);
 if (!isset($SESSION->questionnaire)) {
     $SESSION->questionnaire = new stdClass();
 }
-$questionnaire = new questionnaire(0, $questionnaire, $course, $cm);
+$questionnaire = new questionnaire($course, $cm, 0, $questionnaire);
 
 // Add renderer and page objects to the questionnaire object for display use.
 $questionnaire->add_renderer($PAGE->get_renderer('mod_questionnaire'));

--- a/questions.php
+++ b/questions.php
@@ -14,6 +14,14 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+/**
+ * This page handles the main question editing screen.
+ *
+ * @package    mod_questionnaire
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @copyright  2016 Mike Churchward (mike.churchward@poetopensource.org)
+ */
+
 require_once("../../config.php");
 require_once($CFG->dirroot.'/mod/questionnaire/questionnaire.class.php');
 require_once($CFG->dirroot.'/mod/questionnaire/classes/question/question.php'); // Needed for question type constants.

--- a/questions.php
+++ b/questions.php
@@ -50,7 +50,7 @@ if ($qid) {
 $PAGE->set_url($url);
 $PAGE->set_context($context);
 
-$questionnaire = new questionnaire(0, $questionnaire, $course, $cm);
+$questionnaire = new questionnaire($course, $cm, 0, $questionnaire);
 
 // Add renderer and page objects to the questionnaire object for display use.
 $questionnaire->add_renderer($PAGE->get_renderer('mod_questionnaire'));
@@ -305,7 +305,7 @@ if ($action == 'main') {
 // Reload the form data if called for...
 if ($reload) {
     unset($questionsform);
-    $questionnaire = new questionnaire($questionnaire->id, null, $course, $cm);
+    $questionnaire = new questionnaire($course, $cm, $questionnaire->id, null);
     // Add renderer and page objects to the questionnaire object for display use.
     $questionnaire->add_renderer($PAGE->get_renderer('mod_questionnaire'));
     $questionnaire->add_page(new \mod_questionnaire\output\questionspage());

--- a/report.php
+++ b/report.php
@@ -14,6 +14,15 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+/**
+ * The main report page for a questionnaire.
+ *
+ * @package mod_questionnaire
+ * @copyright  2016 Mike Churchward (mike.churchward@poetgroup.org)
+ * @author     Mike Churchward
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ *
+ */
 require_once("../../config.php");
 require_once($CFG->dirroot.'/mod/questionnaire/questionnaire.class.php');
 
@@ -818,6 +827,7 @@ switch ($action) {
 }
 
 /**
+ * Return a pdf object.
  * @return pdf
  */
 function questionnaire_report_start_pdf() {

--- a/report.php
+++ b/report.php
@@ -62,7 +62,7 @@ if (! $cm = get_coursemodule_from_instance("questionnaire", $questionnaire->id, 
 
 require_course_login($course, true, $cm);
 
-$questionnaire = new questionnaire(0, $questionnaire, $course, $cm);
+$questionnaire = new questionnaire($course, $cm, 0, $questionnaire);
 
 // Add renderer and page objects to the questionnaire object for display use.
 $questionnaire->add_renderer($PAGE->get_renderer('mod_questionnaire'));
@@ -489,7 +489,7 @@ switch ($action) {
         $emailroles = optional_param('emailroles', 0, PARAM_INT);
         $emailextra = optional_param('emailextra', '', PARAM_RAW);
 
-        $output = $questionnaire->generate_csv('', $user, $choicecodes, $choicetext, $currentgroupid, $showincompletes,
+        $output = $questionnaire->generate_csv($currentgroupid, '', $user, $choicecodes, $choicetext, $showincompletes,
             $rankaverages);
 
         $columns = $output[0];

--- a/savefileformat.php
+++ b/savefileformat.php
@@ -31,8 +31,9 @@
  * @param string $dataformat A dataformat name
  * @param array $columns An ordered map of column keys and labels
  * @param Iterator $iterator An iterator over the records, usually a RecordSet
- * @param function $callback An option function applied to each record before writing
- * @param mixed $extra An optional value which is passed into the callback function
+ * @param array $users
+ * @param array $emails
+ * @param string $redirect
  */
 function save_as_dataformat($filename, $dataformat, $columns, $iterator, $users = [], $emails = [], $redirect = '') {
     global $CFG, $OUTPUT;

--- a/settings.php
+++ b/settings.php
@@ -17,9 +17,10 @@
 /**
  * Setting page for questionaire module
  *
- * @package    mod
- * @subpackage questionnaire
+ * @package    mod_questionnaire
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @copyright  2016 onward Mike Churchward (mike.churchward@poetgroup.org)
+ * @author     Mike Churchward
  */
 
 defined('MOODLE_INTERNAL') || die;

--- a/show_nonrespondents.php
+++ b/show_nonrespondents.php
@@ -78,7 +78,7 @@ require_course_login($course, true, $cm);
 $url = new moodle_url('/mod/questionnaire/show_nonrespondents.php', array('id' => $cm->id));
 $PAGE->set_url($url);
 
-$questionnaire = new questionnaire($sid, $questionnaire, $course, $cm);
+$questionnaire = new questionnaire($course, $cm, $sid, $questionnaire);
 
 // Add renderer and page objects to the questionnaire object for display use.
 $questionnaire->add_renderer($PAGE->get_renderer('mod_questionnaire'));

--- a/show_nonrespondents.php
+++ b/show_nonrespondents.php
@@ -15,11 +15,11 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- *
+ * Show the non-respondents to a questionnaire.
  * @author Joseph Rézeau (copied from feedback plugin show_nonrespondents by original author Andreas Grabs)
+ * @copyright  2016 Mike Churchward (mike.churchward@poetopensource.org)
  * @license http://www.gnu.org/copyleft/gpl.html GNU Public License
- * @package    mod
- * @subpackage questionnaire
+ * @package mod_questionnaire
  *
  */
 

--- a/tests/behat/anonymous_questionnaire.feature
+++ b/tests/behat/anonymous_questionnaire.feature
@@ -20,8 +20,7 @@ Feature: Questionnaires can be anonymous
       | questionnaire | Anonymous questionnaire | Anonymous questionnaire description | C1 | questionnaire0 |
     And I log in as "teacher1"
     And I am on "Course 1" course homepage
-    And I follow "Anonymous questionnaire"
-    And I navigate to "Edit settings" in current page administration
+    And I am on the "Anonymous questionnaire" "questionnaire activity editing" page
     And I expand all fieldsets
     And I should see "Response options"
     And I set the field "id_respondenttype" to "anonymous"

--- a/tests/behat/behat_mod_questionnaire.php
+++ b/tests/behat/behat_mod_questionnaire.php
@@ -115,7 +115,7 @@ class behat_mod_questionnaire extends behat_base {
      *
      * @Given /^I click the "([^"]*)" radio button$/
      *
-     * @param string $radiogroupname The "id" attribute of the radio button.
+     * @param int $radioid
      */
     public function i_click_the_radio_button($radioid) {
         $session = $this->getSession();
@@ -357,7 +357,7 @@ class behat_mod_questionnaire extends behat_base {
      * @param array $data Array of data record row arrays. The first row contains the field names.
      * @param string $datatable The name of the data table to insert records into.
      * @param string $mapvar The name of the object variable to store oldid / newid mappings (optional).
-     * @param string $replvars Array of key/value pairs where key is the mapvar and value is the record field
+     * @param array|null $replvars Array of key/value pairs where key is the mapvar and value is the record field
      *                         to replace with mapped values.
      * @return null
      */

--- a/tests/csvexport_test.php
+++ b/tests/csvexport_test.php
@@ -15,22 +15,13 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Test performance of questionnaire.
- * @author    Guy Thomas
- * @copyright Copyright (c) 2015 Moodlerooms Inc. (http://www.moodlerooms.com)
- * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
-defined('MOODLE_INTERNAL') || die();
-
-/**
  * Performance test for questionnaire module.
+ * @package mod_questionnaire
  * @group mod_questionnaire
  * @author     Guy Thomas
  * @copyright Copyright (c) 2015 Moodlerooms Inc. (http://www.moodlerooms.com)
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-
 class mod_questionnaire_csvexport_test extends advanced_testcase {
 
     public function setUp(): void {
@@ -88,6 +79,10 @@ class mod_questionnaire_csvexport_test extends advanced_testcase {
         }
     }
 
+    /**
+     * Return the expected output.
+     * @return string[]
+     */
     private function expected_complete_output() {
         return ["Institution	Department	Course	Group	Full name	Username	Q01_Text Box 1000	Q02_Essay Box 1002	" .
             "Q03_Numeric 1004	Q04_Date 1006	Q05_Radio Buttons 1008	Q06_Drop Down 1010	Q07_Check Boxes 1012->four	" .
@@ -107,6 +102,10 @@ class mod_questionnaire_csvexport_test extends advanced_testcase {
             "27/12/2017	wind	three	0	0	0	0	0	0	0	0	0	1	1	2	3	4	5	1	2	3	4	"];
     }
 
+    /**
+     * Return the exepected incomplete output.
+     * @return string[]
+     */
     private function expected_incomplete_output() {
         return ["Institution	Department	Course	Group	Full name	Username	Complete	Q01_Text Box 1000	" .
             "Q02_Essay Box 1002	" .

--- a/tests/csvexport_test.php
+++ b/tests/csvexport_test.php
@@ -70,17 +70,17 @@ class mod_questionnaire_csvexport_test extends advanced_testcase {
         $questionnaires = $qdg->questionnaires();
         foreach ($questionnaires as $questionnaire) {
             list ($course, $cm) = get_course_and_cm_from_instance($questionnaire->id, 'questionnaire', $questionnaire->course);
-            $questionnaireinst = new questionnaire(0, $questionnaire, $course, $cm);
+            $questionnaireinst = new questionnaire($course, $cm, 0, $questionnaire);
 
             // Test for only complete responses.
-            $newoutput = $this->get_csv_text($questionnaireinst->generate_csv('', '', 0, 0, 0, 0));
+            $newoutput = $this->get_csv_text($questionnaireinst->generate_csv(0, '', '', 0, 0, 0));
             $this->assertEquals(count($newoutput), count($this->expected_complete_output()));
             foreach ($newoutput as $key => $output) {
                 $this->assertEquals($this->expected_complete_output()[$key], $output);
             }
 
             // Test for all responses.
-            $newoutput = $this->get_csv_text($questionnaireinst->generate_csv('', '', 0, 0, 0, 1));
+            $newoutput = $this->get_csv_text($questionnaireinst->generate_csv(0, '', '', 0, 0, 1));
             $this->assertEquals(count($newoutput), count($this->expected_incomplete_output()));
             foreach ($newoutput as $key => $output) {
                 $this->assertEquals($this->expected_incomplete_output()[$key], $output);

--- a/tests/generator/lib.php
+++ b/tests/generator/lib.php
@@ -14,16 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * mod_questionnaire data generator
- *
- * @package    mod_questionnaire
- * @copyright  2015 Mike Churchward (mike@churchward.ca)
- * @author     Mike Churchward
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
-
 defined('MOODLE_INTERNAL') || die();
 
 use mod_questionnaire\generator\question_response,
@@ -33,6 +23,14 @@ use mod_questionnaire\generator\question_response,
 global $CFG;
 require_once($CFG->dirroot.'/mod/questionnaire/locallib.php');
 
+/**
+ * The mod_questionnaire data generator.
+ *
+ * @package    mod_questionnaire
+ * @copyright  2015 Mike Churchward (mike@churchward.ca)
+ * @author     Mike Churchward
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
 class mod_questionnaire_generator extends testing_module_generator {
 
     /**
@@ -51,23 +49,18 @@ class mod_questionnaire_generator extends testing_module_generator {
     protected $questionnaires = [];
 
     /**
-     * To be called from data reset code only,
-     * do not use in tests.
+     * To be called from data reset code only, do not use in tests.
      * @return void
      */
     public function reset() {
         $this->questioncount = 0;
-
         $this->responsecount = 0;
-
         $this->questionnaires = [];
-
         parent::reset();
     }
 
     /**
      * Acessor for questionnaires.
-     *
      * @return array
      */
     public function questionnaires() {
@@ -118,9 +111,9 @@ class mod_questionnaire_generator extends testing_module_generator {
 
     /**
      * Create a survey instance with data from an existing questionnaire object.
-     * @param object $questionnaire
-     * @param array $options
-     * @return int
+     * @param questionnaire $questionnaire
+     * @param array $record
+     * @return bool|int
      */
     public function create_content($questionnaire, $record = array()) {
         global $DB;
@@ -205,6 +198,11 @@ class mod_questionnaire_generator extends testing_module_generator {
 
     /**
      * Create a questionnaire with questions and response data for use in other tests.
+     * @param stdClass $course
+     * @param null|int $qtype
+     * @param array $questiondata
+     * @param null|array|stdClass $choicedata
+     * @return questionnaire
      */
     public function create_test_questionnaire($course, $qtype = null, $questiondata = array(), $choicedata = null) {
         $questionnaire = $this->create_instance(array('course' => $course->id));
@@ -222,6 +220,12 @@ class mod_questionnaire_generator extends testing_module_generator {
 
     /**
      * Create a reponse to the supplied question.
+     * @param questionnaire $questionnaire
+     * @param question $question
+     * @param int|array $respval
+     * @param int $userid
+     * @param int $section
+     * @return false|mixed|stdClass
      */
     public function create_question_response($questionnaire, $question, $respval, $userid = 1, $section = 1) {
         global $DB;
@@ -238,6 +242,9 @@ class mod_questionnaire_generator extends testing_module_generator {
     /**
      * Need to create a method to access a private questionnaire method.
      * TO DO - may not need this with above "TO DO".
+     * @param questionnaire $questionnaire
+     * @param int $responseid
+     * @return mixed
      */
     private function response_commit($questionnaire, $responseid) {
         $method = new ReflectionMethod('questionnaire', 'response_commit');
@@ -247,7 +254,7 @@ class mod_questionnaire_generator extends testing_module_generator {
 
     /**
      * Validate choice question type
-     * @param $data
+     * @param array $data
      * @throws coding_exception
      */
     protected function validate_question_choice($data) {
@@ -258,7 +265,7 @@ class mod_questionnaire_generator extends testing_module_generator {
 
     /**
      * Validate radio question type
-     * @param $data
+     * @param array $data
      * @throws coding_exception
      */
     protected function validate_question_radio($data) {
@@ -269,7 +276,7 @@ class mod_questionnaire_generator extends testing_module_generator {
 
     /**
      * Validate checkbox question type
-     * @param $data
+     * @param array $data
      * @throws coding_exception
      */
     protected function validate_question_check($data) {
@@ -280,7 +287,7 @@ class mod_questionnaire_generator extends testing_module_generator {
 
     /**
      * Validate rating question type
-     * @param $data
+     * @param array $data
      * @throws coding_exception
      */
     protected function validate_question_rate($data) {
@@ -292,8 +299,7 @@ class mod_questionnaire_generator extends testing_module_generator {
     /**
      * Thrown an error if the question isn't receiving the data it should receive.
      * @param string $typeid
-     * @param $data
-     * @throws coding_exception
+     * @param array $data
      */
     protected function validate_question($typeid, $data) {
         if ($typeid == QUESCHOOSE) {
@@ -311,7 +317,7 @@ class mod_questionnaire_generator extends testing_module_generator {
      * Add choices to question.
      *
      * @param \mod_questionnaire\question\question $question
-     * @param stdClass $data
+     * @param array $data
      */
     protected function add_question_choices($question, $data) {
         foreach ($data as $content) {
@@ -331,9 +337,9 @@ class mod_questionnaire_generator extends testing_module_generator {
     }
 
     /**
-     * TODO - use question object
      * Does this question have choices.
-     * @param $typeid
+     * TODO - use question object
+     * @param int $typeid
      * @return bool
      */
     public function question_has_choices($typeid) {
@@ -341,6 +347,11 @@ class mod_questionnaire_generator extends testing_module_generator {
         return in_array($typeid, $choicequestions);
     }
 
+    /**
+     * Return a string value for the int id.
+     * @param int $qtypeid
+     * @return string
+     */
     public function type_str($qtypeid) {
         switch ($qtypeid) {
             case QUESYESNO:
@@ -379,6 +390,11 @@ class mod_questionnaire_generator extends testing_module_generator {
         return $qtype;
     }
 
+    /**
+     * Return a display string for the int id.
+     * @param int $qtypeid
+     * @return string
+     */
     public function type_name($qtypeid) {
         switch ($qtypeid) {
             case QUESYESNO:
@@ -417,6 +433,11 @@ class mod_questionnaire_generator extends testing_module_generator {
         return $qtype;
     }
 
+    /**
+     * Add the response choice.
+     * @param \mod_questionnaire\responsetype\response\response $questionresponse
+     * @param int $responseid
+     */
     protected function add_response_choice($questionresponse, $responseid) {
         global $DB;
 
@@ -545,9 +566,8 @@ class mod_questionnaire_generator extends testing_module_generator {
 
 
     /**
-     * @param int $number
-     *
      * Generate an array of assigned options;
+     * @param int $number
      */
     public function assign_opts($number = 5) {
         static $curpos = 0;
@@ -575,12 +595,12 @@ class mod_questionnaire_generator extends testing_module_generator {
     }
 
     /**
+     * Generate a response.
      * @param questionnaire $questionnaire
      * @param \mod_questionnaire\question\question[] $questions
-     * @param $userid
-     * @param $complete
+     * @param int $userid
+     * @param bool $complete
      * @return stdClass
-     * @throws coding_exception
      */
     public function generate_response($questionnaire, $questions, $userid, $complete = true) {
         $responses = [];
@@ -637,8 +657,15 @@ class mod_questionnaire_generator extends testing_module_generator {
         return $this->create_response($responses, ['questionnaireid' => $questionnaire->id, 'userid' => $userid], $complete);
     }
 
+    /**
+     * Create fully defined questionnaires into the test database.
+     * @param int $coursecount
+     * @param int $studentcount
+     * @param int $questionnairecount
+     * @param int $questionspertype
+     */
     public function create_and_fully_populate($coursecount = 4, $studentcount = 20, $questionnairecount = 2,
-            $questionspertype = 5) {
+                                              $questionspertype = 5) {
         global $DB;
 
         $dg = $this->datagenerator;
@@ -725,6 +752,5 @@ class mod_questionnaire_generator extends testing_module_generator {
                 }
             }
         }
-
     }
 }

--- a/tests/generator/lib.php
+++ b/tests/generator/lib.php
@@ -109,7 +109,7 @@ class mod_questionnaire_generator extends testing_module_generator {
         $instance = parent::create_instance($record, (array)$options);
         $cm = get_coursemodule_from_instance('questionnaire', $instance->id);
         $course = get_course($cm->course);
-        $questionnaire = new questionnaire(0, $instance, $course, $cm, false);
+        $questionnaire = new questionnaire($course, $cm, 0, $instance, false);
 
         $this->questionnaires[$instance->id] = $questionnaire;
 
@@ -216,7 +216,7 @@ class mod_questionnaire_generator extends testing_module_generator {
             $questiondata['content'] = isset($questiondata['content']) ? $questiondata['content'] : 'Test content';
             $this->create_question($questionnaire, $questiondata, $choicedata);
         }
-        $questionnaire = new questionnaire($questionnaire->id, null, $course, $cm, true);
+        $questionnaire = new questionnaire($course, $cm, $questionnaire->id, null, true);
         return $questionnaire;
     }
 
@@ -501,12 +501,12 @@ class mod_questionnaire_generator extends testing_module_generator {
     /**
      * Create response to questionnaire.
      *
-     * @param array|stdClass $record
      * @param array $questionresponses
+     * @param array|stdClass $record
      * @param boolean $complete Whether the response is complete or not.
      * @return stdClass the discussion object
      */
-    public function create_response($record = null, $questionresponses, $complete = true) {
+    public function create_response($questionresponses, $record = null, $complete = true) {
         global $DB;
 
         // Increment the response count.
@@ -634,7 +634,7 @@ class mod_questionnaire_generator extends testing_module_generator {
             }
 
         }
-        return $this->create_response(['questionnaireid' => $questionnaire->id, 'userid' => $userid], $responses, $complete);
+        return $this->create_response($responses, ['questionnaireid' => $questionnaire->id, 'userid' => $userid], $complete);
     }
 
     public function create_and_fully_populate($coursecount = 4, $studentcount = 20, $questionnairecount = 2,

--- a/tests/generator_test.php
+++ b/tests/generator_test.php
@@ -73,7 +73,7 @@ class mod_questionnaire_generator_testcase extends advanced_testcase {
         $generator = $this->getDataGenerator()->get_plugin_generator('mod_questionnaire');
         $questionnaire = $generator->create_instance(array('course' => $course->id));
         $cm = get_coursemodule_from_instance('questionnaire', $questionnaire->id);
-        $questionnaire = new questionnaire($questionnaire->id, null, $course, $cm, false);
+        $questionnaire = new questionnaire($course, $cm, $questionnaire->id, null, false);
 
         $newcontent = array(
             'title'         => 'New title',

--- a/tests/generator_test.php
+++ b/tests/generator_test.php
@@ -26,7 +26,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 /**
- * Unit tests for {@link questionnaire_generator_testcase}.
+ * Unit tests for questionnaire_generator_testcase.
  * @group mod_questionnaire
  */
 class mod_questionnaire_generator_testcase extends advanced_testcase {

--- a/tests/lib_test.php
+++ b/tests/lib_test.php
@@ -32,7 +32,7 @@ require_once($CFG->dirroot.'/mod/questionnaire/lib.php');
 require_once($CFG->dirroot.'/mod/questionnaire/classes/question/question.php');
 
 /**
- * Unit tests for {@link questionnaire_lib_testcase}.
+ * Unit tests for questionnaire_lib_testcase.
  * @group mod_questionnaire
  */
 class mod_questionnaire_lib_testcase extends advanced_testcase {

--- a/tests/questiontypes_test.php
+++ b/tests/questiontypes_test.php
@@ -129,7 +129,7 @@ class mod_questionnaire_questiontypes_testcase extends advanced_testcase {
         }
 
         // Questionnaire object should now have question record(s).
-        $questionnaire = new questionnaire($questionnaire->id, null, $course, $cm, true);
+        $questionnaire = new questionnaire($course, $cm, $questionnaire->id, null, true);
         $this->assertTrue($DB->record_exists('questionnaire_question', array('id' => $question->id)));
         $this->assertEquals('array', gettype($questionnaire->questions));
         $this->assertTrue(array_key_exists($question->id, $questionnaire->questions));

--- a/tests/questiontypes_test.php
+++ b/tests/questiontypes_test.php
@@ -31,7 +31,7 @@ global $CFG;
 require_once($CFG->dirroot.'/mod/questionnaire/locallib.php');
 
 /**
- * Unit tests for {@link questionnaire_questiontypes_testcase}.
+ * Unit tests for questionnaire_questiontypes_testcase.
  * @group mod_questionnaire
  */
 class mod_questionnaire_questiontypes_testcase extends advanced_testcase {
@@ -93,6 +93,13 @@ class mod_questionnaire_questiontypes_testcase extends advanced_testcase {
 
     // General tests to call from specific tests above.
 
+    /**
+     * Create a test question.
+     * @param int $qtype
+     * @param question $questionclass
+     * @param array $questiondata
+     * @param null|array $choicedata
+     */
     private function create_test_question($qtype, $questionclass, $questiondata = array(), $choicedata = null) {
         global $DB;
 
@@ -139,6 +146,13 @@ class mod_questionnaire_questiontypes_testcase extends advanced_testcase {
         }
     }
 
+    /**
+     * Create a test question with choices.
+     * @param int $qtype
+     * @param question $questionclass
+     * @param array $questiondata
+     * @param null|array $choicedata
+     */
     private function create_test_question_with_choices($qtype, $questionclass, $questiondata = array(), $choicedata = null) {
         if ($choicedata === null) {
             $choicedata = array(

--- a/tests/responsetypes_test.php
+++ b/tests/responsetypes_test.php
@@ -299,7 +299,7 @@ class mod_questionnaire_responsetypes_testcase extends advanced_testcase {
         $questiondata['content'] = isset($questiondata['content']) ? $questiondata['content'] : 'Test content';
         $generator->create_question($questionnaire, $questiondata, $choicedata);
 
-        $questionnaire = new questionnaire($questionnaire->id, null, $course, $cm, true);
+        $questionnaire = new questionnaire( $course, $cm, $questionnaire->id, null, true);
 
         return $questionnaire;
     }

--- a/tests/responsetypes_test.php
+++ b/tests/responsetypes_test.php
@@ -33,7 +33,7 @@ require_once($CFG->dirroot . '/mod/questionnaire/tests/generator_test.php');
 require_once($CFG->dirroot . '/mod/questionnaire/tests/questiontypes_test.php');
 
 /**
- * Unit tests for {@link questionnaire_responsetypes_testcase}.
+ * Unit tests for questionnaire_responsetypes_testcase.
  * @group mod_questionnaire
  */
 class mod_questionnaire_responsetypes_testcase extends advanced_testcase {
@@ -285,6 +285,14 @@ class mod_questionnaire_responsetypes_testcase extends advanced_testcase {
 
     // General tests to call from specific tests above.
 
+    /**
+     * Create a test questionnaire.
+     *
+     * @param int $qtype
+     * @param array $questiondata
+     * @param null $choicedata
+     * @return questionnaire
+     */
     public function create_test_questionnaire($qtype, $questiondata = [], $choicedata = null) {
         $this->resetAfterTest();
 
@@ -304,6 +312,15 @@ class mod_questionnaire_responsetypes_testcase extends advanced_testcase {
         return $questionnaire;
     }
 
+    /**
+     * General assertions for responses.
+     *
+     * @param int $questionnaireid
+     * @param int $responseid
+     * @param int $userid
+     * @param int $attemptcount
+     * @param int $responsecount
+     */
     private function response_tests($questionnaireid, $responseid, $userid,
                                     $attemptcount = 1, $responsecount = 1) {
         global $DB;

--- a/version.php
+++ b/version.php
@@ -24,10 +24,10 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version  = 2020111101;  // The current module version (Date: YYYYMMDDXX).
-$plugin->requires = 2020061500; // Moodle version (3.9).
+$plugin->version  = 2022030301;  // The current module version (Date: YYYYMMDDXX).
+$plugin->requires = 2022030300; // Moodle version (4.0).
 
 $plugin->component = 'mod_questionnaire';
 
-$plugin->release  = '3.10.1 (Build - 2021080400)';
-$plugin->maturity  = MATURITY_STABLE;
+$plugin->release  = '4.0.0 (Build - 2022030300)';
+$plugin->maturity  = MATURITY_BETA;

--- a/version.php
+++ b/version.php
@@ -19,6 +19,7 @@
  *
  * @package mod_questionnaire
  * @author  Mike Churchward
+ * @copyright  2016 Mike Churchward (mike.churchward@poetopensource.org)
  * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/view.php
+++ b/view.php
@@ -14,6 +14,15 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+/**
+ * This main view page for a questionnaire.
+ *
+ * @package mod_questionnaire
+ * @copyright  2016 Mike Churchward (mike.churchward@poetgroup.org)
+ * @author     Mike Churchward
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ *
+ */
 require_once("../../config.php");
 require_once($CFG->dirroot.'/mod/questionnaire/locallib.php');
 require_once($CFG->libdir . '/completionlib.php');

--- a/view.php
+++ b/view.php
@@ -47,7 +47,7 @@ if (isset($sid)) {
 
 $PAGE->set_url($url);
 $PAGE->set_context($context);
-$questionnaire = new questionnaire(0, $questionnaire, $course, $cm);
+$questionnaire = new questionnaire($course, $cm, 0, $questionnaire);
 // Add renderer and page objects to the questionnaire object for display use.
 $questionnaire->add_renderer($PAGE->get_renderer('mod_questionnaire'));
 $questionnaire->add_page(new \mod_questionnaire\output\viewpage());


### PR DESCRIPTION
Fixes array_key_exists errors in label text when the scorecalculation field is empty string and not array.

This happens when:

1. You select 'feedback sections' option in the 'feedback' tab
2. You select 'Save settings and edit Feedback Sections'
3. You don't then save on the resulting feedback sections screen

Also sets the initial feedback section DB record to have empty serialised array instead of empty string so data matches completed records