### PR TITLE
Questionnaire: Error when trying to delete a question

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -756,7 +756,7 @@ function questionnaire_check_page_breaks($questionnaire) {
 
         $dependencies = $DB->get_records('questionnaire_dependency', ['questionid' => $key , 'surveyid' => $sid],
                 'id ASC', 'id, dependquestionid, dependchoiceid, dependlogic');
-        $positions[$qu->position]['dependencies'] = $dependencies;
+        $positions[$qu->position]['dependencies'] = $dependencies ?? [];
     }
     $count = count($positions);
 


### PR DESCRIPTION
Fixes for the following errors when deleting questions or page breaks:

Error 1:

Exception - count(): Argument #1 ($value) must be of type Countable|array, stdClass given

Error code: generalexceptionmessage

line 190 of /mod/questionnaire/questions.php: TypeError thrown
line 190 of /mod/questionnaire/questions.php: call to count()

Error 2:

Exception - count(): Argument #1 ($value) must be of type Countable|array, null given

Error code: generalexceptionmessage

line 799 of /mod/questionnaire/locallib.php: TypeError thrown
line 799 of /mod/questionnaire/locallib.php: call to count()
line 133 of /mod/questionnaire/questions.php: call to questionnaire_check_page_breaks()
